### PR TITLE
Stable

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_font-face.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_font-face.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "shared";
 
 // Cross-browser support for @font-face. Supports IE, Gecko, Webkit, Opera.


### PR DESCRIPTION
Declaring UTF-8 in _font-face.scss allows SASS to successfully compile the file on systems where UTF-8 is not the default. Been running this without incident for a week or two.
