### PR TITLE
IE8 compatibility with :last-child selectors

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/lists/_horizontal-list.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/lists/_horizontal-list.scss
@@ -31,6 +31,9 @@
 //
 // :last-child is not fully supported
 // see http://www.quirksmode.org/css/contents.html#t29 for the support matrix
+// 
+// IE8 ignores rules that are included on the same line as :last-child
+// see http://www.richardscarrott.co.uk/posts/view/ie8-last-child-bug for details
 //
 // Setting `$padding` to `false` disables the padding between list elements
 @mixin horizontal-list-item($padding: 4px, $direction: left) {
@@ -43,7 +46,8 @@
       right: $padding;
     }
     &:first-child, &.first { padding-#{$direction}: 0; }
-    &:last-child, &.last   { padding-#{opposite-position($direction)}: 0; }
+    &:last-child { padding-#{opposite-position($direction)}: 0; }
+    &.last { padding-#{opposite-position($direction)}: 0; }
   }
 }
 

--- a/frameworks/compass/stylesheets/compass/utilities/lists/_inline-list.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/lists/_inline-list.scss
@@ -17,12 +17,18 @@
 //
 // `:last-child` is not fully supported.
 // see quirksmode for the [support matrix](http://www.quirksmode.org/css/contents.html#t29).
+//
+// IE8 ignores rules that are included on the same line as :last-child
+// see http://www.richardscarrott.co.uk/posts/view/ie8-last-child-bug for details
 
 @mixin comma-delimited-list {
   @include inline-list;
   li {
     &:after { content: ", "; }
-    &:last-child, &.last {
+    &:last-child {
+      &:after { content: ""; }
+    }
+    &.last {
       &:after { content: ""; }
     }
   }

--- a/frameworks/compass/stylesheets/compass/utilities/tables/_borders.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/tables/_borders.scss
@@ -20,8 +20,14 @@
     &:last-child,
     &.last {
       border-right-width: 0px; } }
+
+// IE8 ignores rules that are included on the same line as :last-child
+// see http://www.richardscarrott.co.uk/posts/view/ie8-last-child-bug for details
+
   tbody, tfoot {
-    tr:last-child,
+    tr:last-child {
+      th, td {
+        border-bottom-width: 0px; } }
     tr.last {
       th, td {
         border-bottom-width: 0px; } } } }


### PR DESCRIPTION
This request separates any rules within compass that include a :last-child selector. IE8 with IE8 standards will ignore all selectors that are on the same line as a :last-child selector. Separating :last-child from these selectors fixes the issue.

More information can be found here: http://www.richardscarrott.co.uk/posts/view/ie8-last-child-bug
