### PR TITLE
sass dependecy fix

### DIFF
--- a/compass.gemspec
+++ b/compass.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gemspec|
   gemspec.rubygems_version = "1.3.5"
   gemspec.summary = %q{A Real Stylesheet Framework}
 
-  gemspec.add_dependency 'sass', '>= 3.1.0.alpha.50'
+  gemspec.add_dependency 'sass', '~> 3.1.0'
   gemspec.add_dependency 'chunky_png', '~> 0.10.3'
 
   gemspec.files = %w(README.markdown LICENSE.markdown VERSION.yml Rakefile)


### PR DESCRIPTION
after today's sass version bump i got this problem

<pre>
Bundler could not find compatible versions for gem "sass":
  In Gemfile:
    compass depends on
      sass (>= 3.1.0.alpha.50)

    sass (3.1.0.alpha.0)
</pre>
