### PR TITLE
Added a reset-float mixin

### DIFF
--- a/frameworks/compass/stylesheets/compass/reset/_utilities.scss
+++ b/frameworks/compass/stylesheets/compass/reset/_utilities.scss
@@ -144,9 +144,6 @@
 // body.signup
 //   #footer li
 //     +reset-float
-@mixin reset-float($inline: block) {
+@mixin reset-float($display: block) {
   float: none;
-  @if $inline == inline {
-    display: inline; }
-  @else {
-    display: block; } }
+  display: $display; }

--- a/frameworks/compass/stylesheets/compass/reset/_utilities.scss
+++ b/frameworks/compass/stylesheets/compass/reset/_utilities.scss
@@ -133,3 +133,20 @@
       display: block !important; }
     @else {
       display: block; } } }
+
+// Resets floated elements back to their dfault of float: none and defaults
+// to display: block unless you pass the string 'inline' as an argument
+// Usage Example:
+//
+// body.homepage
+//   #footer li
+//     +float-left
+// body.signup
+//   #footer li
+//     +reset-float
+@mixin reset-float($inline: block) {
+  float: none;
+  @if $inline == inline {
+    display: inline; }
+  @else {
+    display: block; } }


### PR DESCRIPTION
I've used this often enough and thought, why the heck don't I add this to Compass.

There have been a number of cases where I wanted to reset a float created by one of the float mixins such as `+float-left`. Before I wrote this, I would have to set the element to `float: none` and then also set `display: block` to reset the changed display. Using this mixin, you would use `+reset-float` to reset the float and if the element is inline you can pass the argument 'inline' to keep the element's display set to inline, for example `+reset-float(inline)`.
