### PR TITLE
here is the generalized delimited-list

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/lists/_inline-list.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/lists/_inline-list.scss
@@ -9,8 +9,10 @@
   }
 }
 
-// makes an inline list that is comma delimited.
-// Please make note of the browser support issues before using this mixin.
+// makes an inline list delimited with the passed string.
+// Defaults to making a comma-separated list.
+//
+// Please make note of the browser support issues before using this mixin:
 //
 // use of `content` and `:after` is not fully supported in all browsers.
 // See quirksmode for the [support matrix](http://www.quirksmode.org/css/contents.html#t15)
@@ -21,10 +23,10 @@
 // IE8 ignores rules that are included on the same line as :last-child
 // see http://www.richardscarrott.co.uk/posts/view/ie8-last-child-bug for details
 
-@mixin comma-delimited-list {
+@mixin delimited-list($separator: ", ") {
   @include inline-list;
   li {
-    &:after { content: ", "; }
+    &:after { content: $separator; }
     &:last-child {
       &:after { content: ""; }
     }
@@ -32,4 +34,10 @@
       &:after { content: ""; }
     }
   }
+}
+
+// deprecated. See `delimited-list`
+
+@mixin comma-delimited-list {
+  @include delimited-list
 }


### PR DESCRIPTION
I don't know the process for marking stylesheet features deprecated, so I just noted it in the comments above "comma-delimited-list" (it now does the same thing as "delimited-list" with no argument, so it seems fairly useless to me).

One of the tests causes compass to throw a deprecation warning. I didn't add any scss files or touch the tests so I assume it wasn't me.

The cucumber tests gave all sorts of failures. I assume I have no responsibility for that. :-\
