### PR TITLE
Call backs not moving down from top of the linked list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    compass (0.11.beta.2.0dc38bc)
+    compass (0.11.beta.2.8a8ef87)
       chunky_png (~> 0.12.0)
       sass (>= 3.1.0.alpha.218)
 

--- a/lib/compass/configuration/data.rb
+++ b/lib/compass/configuration/data.rb
@@ -137,10 +137,10 @@ module Compass
 
       def run_callback(event, *args)
         begin
-          send(:"run_#{event}", *args)
+          Compass.configuration.send(:"run_#{event}", *args)
         rescue NoMethodError => e
           unless e.message =~ /run_#{event}/
-            raise
+           raise
           end
         end
       end

--- a/lib/compass/configuration/data.rb
+++ b/lib/compass/configuration/data.rb
@@ -140,7 +140,7 @@ module Compass
           Compass.configuration.send(:"run_#{event}", *args)
         rescue NoMethodError => e
           unless e.message =~ /run_#{event}/
-           raise
+            raise
           end
         end
       end


### PR DESCRIPTION
In the way you implemented if you add config options before the project config is loaded those callbacks never get called. Because call backs only move down the list and not up events should start from the top and move the entire way down the list since it is possible to make call backs defined on "n" config objects. This seems like a crud way todo it in my patch here but it gets the point across what may need to be adjusted.
