### PR TITLE
Webkit linear-gradient support

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_gradient.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_gradient.scss
@@ -2,29 +2,29 @@
 
 // This yields a linear gradient spanning from top to bottom
 //
-//     +linear-gradient(color-stops(white, black))
+//     +linear-gradient("white, black")
 //
 // This yields a linear gradient spanning from bottom to top
 //
-//     +linear-gradient(color-stops(white, black), bottom)
+//     +linear-gradient("white, black", bottom)
 //
 // This yields a linear gradient spanning from left to right
 //
-//     +linear-gradient(color-stops(white, black), left)
+//     +linear-gradient("white, black", left)
 //
 // This yields a linear gradient starting at white passing
 // thru blue at 33% down and then to black
 //
-//     +linear-gradient(color-stops(white, blue 33%, black))
+//     +linear-gradient("white, blue 33%, black")
 //
 // This yields a linear gradient starting at white passing
 // thru blue at 33% down and then to black at 67% until the end
 //
-//     +linear-gradient(color-stops(white, blue 33%, black 67%))
+//     +linear-gradient("white, blue 33%, black 67%")
 //
 // This yields a linear gradient on top of a background image
 //
-//     +linear-gradient(color_stops(white,black), top, image-url('noise.png'))
+//     +linear-gradient("white, black", top, image-url('noise.png'))
 // Browsers Supported:
 //
 // - Chrome
@@ -33,18 +33,19 @@
 
 @mixin linear-gradient($color-stops, $start: top, $image: false) {
   // Firefox's gradient api is nice.
-  // Webkit's gradient api sucks -- hence these backflips:
+  // Webkit's gradient api doesn't suck anymore:
   $background: unquote("");
-  @if $image { $background : $image + unquote(", "); }
+  @if $image { $background: $image + unquote(", "); }
+  $color-stops: unquote($color-stops);
   $start: unquote($start);
   $end: opposite-position($start);
   @if $experimental-support-for-webkit {
-    background-image: #{$background}-webkit-gradient(linear, grad-point($start), grad-point($end), grad-color-stops($color-stops));
+    background: #{$background}-webkit-linear-gradient($start, $color-stops);
   }
   @if $experimental-support-for-mozilla {
-    background-image: #{$background}-moz-linear-gradient($start, $color-stops);
+    background: #{$background}-moz-linear-gradient($start, $color-stops);
   }
-  background-image: #{$background}linear-gradient($start, $color-stops);
+  background: #{$background}linear-gradient($start, $color-stops);
 }
 
 // Due to limitation's of webkit, the radial gradient mixin works best if you use


### PR DESCRIPTION
Webkit are now in line with the spec for linear-gradient support, so I have updated this mixin to accommodate.

I've changed the properties to 'background', not sure why but my styles at least wouldn't work on 'background-image'. I imagine it's either to do with multiple background or gradient support? Either way, changing it fixed it and I have no desire to continue my examination as to why it did.

Webkit have also brought radial-gradient in line with the spec, this should also be updated at some point. Again, I don't need this right now so haven't made the changes myself, they are invariably similar however except that the start/end positions are set as the first parameters and then the colours last rather than position, colour pairs, perhaps it would be wise to simply accept one quoted parameter to allow for full flexibility, I think I'm right in saying most modern browsers that support gradients are now using the same syntax anyway, thus we only need vendor replication.
