### PR TITLE
New forcewrap mixin

### DIFF
--- a/doc-src/content/reference/compass/typography/text/forcewrap.haml
+++ b/doc-src/content/reference/compass/typography/text/forcewrap.haml
@@ -2,14 +2,13 @@
 title: Wrapping Long Text and URLs
 crumb: Force Wrap
 framework: compass
-stylesheet: compass/utilities/text/_forcewrap.scss
+stylesheet: compass/typography/text/_forcewrap.scss
 layout: core
 meta_description: Wrap URLs and long lines of text.
-nav_stylesheet: compass/_utilities.scss
 classnames:
   - reference
   - core
-  - utilities
+  - typography
 ---
 - render 'reference' do
   %p

--- a/doc-src/content/reference/compass/typography/text/forcewrap.haml
+++ b/doc-src/content/reference/compass/typography/text/forcewrap.haml
@@ -1,0 +1,16 @@
+--- 
+title: Wrapping Long Text and URLs
+crumb: Force Wrap
+framework: compass
+stylesheet: compass/utilities/text/_forcewrap.scss
+layout: core
+meta_description: Wrap URLs and long lines of text.
+nav_stylesheet: compass/_utilities.scss
+classnames:
+  - reference
+  - core
+  - utilities
+---
+- render 'reference' do
+  %p
+    This mixin will wrap URLs and long lines of text to prevent text from breaking layouts.

--- a/frameworks/compass/stylesheets/compass/typography/_text.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_text.scss
@@ -1,3 +1,4 @@
 @import "text/ellipsis";
 @import "text/nowrap";
 @import "text/replacement";
+@import "text/forcewrap";

--- a/frameworks/compass/stylesheets/compass/typography/text/_forcewrap.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_forcewrap.scss
@@ -1,0 +1,11 @@
+/* used to prevent long urls and text from breaking layouts */
+@mixin forcewrap {
+  white-space: pre;           /* CSS 2.0 */
+  white-space: pre-wrap;      /* CSS 2.1 */
+  white-space: pre-line;      /* CSS 3.0 */
+  white-space: -pre-wrap;     /* Opera 4-6 */
+  white-space: -o-pre-wrap;   /* Opera 7 */
+  white-space: -moz-pre-wrap; /* Mozilla */
+  white-space: -hp-pre-wrap;  /* HP Printers */
+  word-wrap: break-word;      /* IE 5+ */
+}

--- a/frameworks/compass/stylesheets/compass/utilities/_text.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/_text.scss
@@ -3,3 +3,4 @@
 @import "../typography/text/ellipsis";
 @import "../typography/text/nowrap";
 @import "../typography/text/replacement";
+@import "../typography/text/forcewrap";

--- a/frameworks/compass/stylesheets/compass/utilities/text/_forcewrap.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/text/_forcewrap.scss
@@ -1,0 +1,11 @@
+// used to prevent long urls and text from breaking layouts
+@mixin forcewrap {
+  white-space: pre;           /* CSS 2.0 */
+  white-space: pre-wrap;      /* CSS 2.1 */
+  white-space: pre-line;      /* CSS 3.0 */
+  white-space: -pre-wrap;     /* Opera 4-6 */
+  white-space: -o-pre-wrap;   /* Opera 7 */
+  white-space: -moz-pre-wrap; /* Mozilla */
+  white-space: -hp-pre-wrap;  /* HP Printers */
+  word-wrap: break-word;      /* IE 5+ */
+}


### PR DESCRIPTION
As discussed in the Compass google group.  Here is a forcewrap mixin that will wrap long URLs and text to prevent text from breaking layouts.

This is my first time contributing to Compass so I hope I have included everything.

-Glenn
@gmclelland - twitter
