### PR TITLE
blueprint-form-borders

### DIFF
--- a/frameworks/blueprint/stylesheets/blueprint/_form.scss
+++ b/frameworks/blueprint/stylesheets/blueprint/_form.scss
@@ -59,7 +59,7 @@
     background-color:#fff;
     border: 1px solid $unfocused-border-color;
     &:focus {
-      border: 1px solid $focus-border-color;
+      border-color: $focus-border-color;
     }
   }
   select { background-color:#fff; border-width:1px; border-style:solid; }


### PR DESCRIPTION
slight modification to because :focus should not use shorthand border property, since it only need to change the border-color.
