### PR TITLE
Enable IE 10 support for flexible box with the -ms prefix.

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_box.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_box.scss
@@ -3,7 +3,7 @@
 // display:box; must be used for any of the other flexbox mixins to work properly
 @mixin display-box {
   @include experimental-value(display, box,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -16,7 +16,7 @@ $default-box-orient: horizontal !default;
 ) {
   $orientation : unquote($orientation);
   @include experimental(box-orient, $orientation,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -29,7 +29,7 @@ $default-box-align: stretch !default;
 ) {
   $alignment : unquote($alignment);
   @include experimental(box-align, $alignment,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -43,7 +43,7 @@ $default-box-flex: 0 !default;
   $flex: $default-box-flex
 ) {
   @include experimental(box-flex, $flex,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -55,7 +55,7 @@ $default-box-flex-group: 1 !default;
   $group: $default-box-flex-group
 ) {
   @include experimental(box-flex-group, $group,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -67,7 +67,7 @@ $default-box-ordinal-group: 1 !default;
   $group: $default-ordinal-flex-group
 ) {
   @include experimental(box-ordinal-group, $group,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -80,7 +80,7 @@ $default-box-direction: normal !default;
 ) {
   $direction: unquote($direction);
   @include experimental(box-direction, $direction,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -93,7 +93,7 @@ $default-box-lines: single !default;
 ) {
   $lines: unquote($lines);
   @include experimental(box-lines, $lines,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }
 
@@ -106,6 +106,6 @@ $default-box-pack: start !default;
 ) {
   $pack: unquote($pack);
   @include experimental(box-pack, $pack,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }

--- a/test/fixtures/stylesheets/compass/css/box.css
+++ b/test/fixtures/stylesheets/compass/css/box.css
@@ -1,84 +1,103 @@
 .hbox {
   display: -moz-box;
   display: -webkit-box;
+  display: -ms-box;
   display: box;
   -moz-box-orient: horizontal;
   -webkit-box-orient: horizontal;
+  -ms-box-orient: horizontal;
   box-orient: horizontal;
   -moz-box-align: stretch;
   -webkit-box-align: stretch;
+  -ms-box-align: stretch;
   box-align: stretch; }
   .hbox > * {
     -moz-box-flex: 0;
     -webkit-box-flex: 0;
+    -ms-box-flex: 0;
     box-flex: 0; }
 
 .vbox {
   display: -moz-box;
   display: -webkit-box;
+  display: -ms-box;
   display: box;
   -moz-box-orient: vertical;
   -webkit-box-orient: vertical;
+  -ms-box-orient: vertical;
   box-orient: vertical;
   -moz-box-align: stretch;
   -webkit-box-align: stretch;
+  -ms-box-align: stretch;
   box-align: stretch; }
   .vbox > * {
     -moz-box-flex: 0;
     -webkit-box-flex: 0;
+    -ms-box-flex: 0;
     box-flex: 0; }
 
 .spacer {
   -moz-box-flex: 1;
   -webkit-box-flex: 1;
+  -ms-box-flex: 1;
   box-flex: 1; }
 
 .reverse {
   -moz-box-direction: reverse;
   -webkit-box-direction: reverse;
+  -ms-box-direction: reverse;
   box-direction: reverse; }
 
 .box-flex-0 {
   -moz-box-flex: 0;
   -webkit-box-flex: 0;
+  -ms-box-flex: 0;
   box-flex: 0; }
 
 .box-flex-1 {
   -moz-box-flex: 1;
   -webkit-box-flex: 1;
+  -ms-box-flex: 1;
   box-flex: 1; }
 
 .box-flex-2 {
   -moz-box-flex: 2;
   -webkit-box-flex: 2;
+  -ms-box-flex: 2;
   box-flex: 2; }
 
 .box-flex-group-0 {
   -moz-box-flex-group: 0;
   -webkit-box-flex-group: 0;
+  -ms-box-flex-group: 0;
   box-flex-group: 0; }
 
 .box-flex-group-1 {
   -moz-box-flex-group: 1;
   -webkit-box-flex-group: 1;
+  -ms-box-flex-group: 1;
   box-flex-group: 1; }
 
 .box-flex-group-2 {
   -moz-box-flex-group: 2;
   -webkit-box-flex-group: 2;
+  -ms-box-flex-group: 2;
   box-flex-group: 2; }
 
 .start {
   -moz-box-pack: start;
   -webkit-box-pack: start;
+  -ms-box-pack: start;
   box-pack: start; }
 
 .end {
   -moz-box-pack: end;
   -webkit-box-pack: end;
+  -ms-box-pack: end;
   box-pack: end; }
 
 .center {
   -moz-box-pack: center;
   -webkit-box-pack: center;
+  -ms-box-pack: center;
   box-pack: center; }


### PR DESCRIPTION
IE 10 supports the CSS3 flexible box properties, with the -ms prefix.

http://ie.microsoft.com/testdrive/HTML5/Flexin/Default.html
