### PR TITLE
Actions should obey options[:quiet]

### DIFF
--- a/lib/compass/actions.rb
+++ b/lib/compass/actions.rb
@@ -24,7 +24,7 @@ module Compass
         msg = "#{basename(dir)} already exists and is not a directory."
         raise Compass::FilesystemConflict.new(msg)
       else
-        logger.record :directory, separate("#{basename(dir)}/")
+        logger.record(:directory, separate("#{basename(dir)}/")) unless options[:quiet]
         FileUtils.mkdir_p(dir) unless options[:dry_run]
       end
     end
@@ -38,16 +38,16 @@ module Compass
       if File.exists?(file_name)
         existing_contents = IO.read(file_name)
         if existing_contents == contents
-          logger.record :identical, basename(file_name), extra
+          logger.record(:identical, basename(file_name), extra) unless options[:quiet]
           skip_write = true
         elsif options[:force]
-          logger.record :overwrite, basename(file_name), extra
+          logger.record(:overwrite, basename(file_name), extra) unless options[:quiet]
         else
           msg = "File #{basename(file_name)} already exists. Run with --force to force overwrite."
           raise Compass::FilesystemConflict.new(msg)
         end
       else
-        logger.record :create, basename(file_name), extra
+        logger.record(:create, basename(file_name), extra) unless options[:quiet]
       end
       if skip_write
         FileUtils.touch file_name unless options[:dry_run]
@@ -68,7 +68,7 @@ module Compass
     def remove(file_name)
       if File.exists?(file_name)
         File.unlink file_name
-        logger.record :remove, basename(file_name)
+        logger.record(:remove, basename(file_name)) unless options[:quiet]
       end
     end
 

--- a/lib/compass/actions.rb
+++ b/lib/compass/actions.rb
@@ -17,6 +17,7 @@ module Compass
     # create a directory and all the directories necessary to reach it.
     def directory(dir, options = nil)
       options ||= self.options if self.respond_to?(:options)
+      options ||= {}
       if File.exists?(dir) && File.directory?(dir)
           # logger.record :exists, basename(dir) unless options[:quiet]
       elsif File.exists?(dir)

--- a/test/units/actions_test.rb
+++ b/test/units/actions_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'compass'
+
+class ActionsTest < Test::Unit::TestCase
+  class BaseActionExtender
+    include Compass::Actions
+    def options
+      @@options ||= {}
+    end
+    def working_path
+      "/tmp"
+    end
+  end
+  
+  # When log4r is included, it sometimes breaks the Actions
+  def test_quiet_option
+    b = BaseActionExtender.new
+    b.logger = ""
+    b.options[:quiet] = true
+
+    # logger shouldn't be called... if it is, this will error
+    b.directory("/tmp/#{(rand * 1000000).to_i}")
+  end
+end


### PR DESCRIPTION
Currently, Actions will try and log tho their hearts content instead of obeying options[:quiet]

I needed this to get around another issue I was having that I'm still investigating. But, since
other classes that _include_ Actions obey this rule with logging, then so should Actions.

Without this patch, you could make a compiler... tell it to be quiet... and it would _still_ report
stuff from actions (even though its custom-methods are being quiet)
