### PR TITLE
Fixed css3 example of background property image URL.

### DIFF
--- a/doc-src/content/reference/compass/css3/images.haml
+++ b/doc-src/content/reference/compass/css3/images.haml
@@ -25,7 +25,7 @@ classnames:
     Example (more examples are available by following the links below):
     
     <pre><code class="source-code scss">.in-css3 {
-      background: image-url("foo.png"),
+      background: url(foo.png),
                   linear-gradient(top left, #333, #0c0),
                   radial-gradient(#c00, #fff 100px);
     }


### PR DESCRIPTION
Just a one-line fix of one of the CSS3 examples.
