### PR TITLE
Just ignore writing the file if we don't have access to it

### DIFF
--- a/lib/compass/actions.rb
+++ b/lib/compass/actions.rb
@@ -57,6 +57,8 @@ module Compass
           file.write(contents)
         end
       end
+    rescue Errno::EACCES
+      false
     end
 
     def process_erb(contents, ctx = nil)


### PR DESCRIPTION
In readonly environments (like heroku), write_file can't work as we can't write the css file.

In these cases, we must just ignore and leave it as it is as this is usually production environments and the static file is the one which should be rendered.
