### PR TITLE
Fixed broken link in Helpers documenation

### DIFF
--- a/doc-src/content/reference/compass/helpers.haml
+++ b/doc-src/content/reference/compass/helpers.haml
@@ -15,7 +15,7 @@ layout: core
 
 :markdown
   The compass helpers are functions that augment the [functions provided
-  by Sass](http://sass-lang.com/yardoc/Sass/Script/Functions.html).
+  by Sass](http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html).
   
   All Helpers:
   


### PR DESCRIPTION
Broken link fixed to what I think is the correct section of the SASS docs.
