### PR TITLE
Fix typo in SpriteImporter

### DIFF
--- a/lib/compass/sprite_importer.rb
+++ b/lib/compass/sprite_importer.rb
@@ -65,7 +65,7 @@ module Compass
       if uri =~ SPRITE_IMPORTER_REGEX
         [$1, $3]
       else
-        raise Compass::Error "invalid sprite path"
+        raise Compass::Error, "invalid sprite path"
       end
     end
 


### PR DESCRIPTION
This patch fixes the call to raise in Compass::SpriteImporter.path_and_name, so that the following error is not produced:

```
undefined method `Error' for Compass:Module
```
