### PR TITLE
Rails 3.1 image (and other) assets

### DIFF
--- a/lib/compass/app_integration/rails/configuration_defaults.rb
+++ b/lib/compass/app_integration/rails/configuration_defaults.rb
@@ -6,28 +6,39 @@ module Compass
         # These methods overwrite the old rails defaults
         # when rails 3.1 is detected.
 
+        # Assets dir is configurable, but rails doesn't provide the default
+        def default_assets_dir
+          ::Rails.application.config.assets.assets_dir.presence || File.join("app", "assets")
+        end
+
+        # These two have special case overrides:
+
         def default_sass_dir
-          File.join("app", "assets", "stylesheets")
-        end
-
-        def default_images_dir
-          File.join("app", "assets", "images")
-        end
-
-        def default_fonts_dir
-          File.join("app", "assets", "fonts")
+          ::Rails.application.config.assets.stylesheets_dir.presence || File.join(default_assets_dir, "stylesheets")
         end
 
         def default_javascripts_dir
-          File.join("app", "assets", "javascripts")
+          ::Rails.application.config.assets.javascripts_dir.presence || File.join(default_assets_dir, "javascripts")
         end
 
-        # Everything is now overlaid and served from the assets path
+        # These two are just conventions:
+
+        def default_images_dir
+          File.join(default_assets_dir, "images")
+        end
+
+        def default_fonts_dir
+          File.join(default_assets_dir, "fonts")
+        end
+
+        # For HTTP paths, everything is now overlaid and served from the assets path
 
         def default_http_assets_path
-          "#{top_level.http_path}assets"
+          # XXX: Should this take asset_host into account?
+          ::Rails.application.config.assets.prefix
         end
 
+        # These are all cascaded in the asset pipeline
         alias default_http_images_path default_http_assets_path
         alias default_http_javascripts_path default_http_assets_path
         alias default_http_fonts_path default_http_assets_path

--- a/lib/compass/app_integration/rails/configuration_defaults.rb
+++ b/lib/compass/app_integration/rails/configuration_defaults.rb
@@ -43,6 +43,29 @@ module Compass
         alias default_http_javascripts_path default_http_assets_path
         alias default_http_fonts_path default_http_assets_path
         alias default_http_stylesheets_path default_http_assets_path
+
+        # Use Sprockets to figure out paths to assets:
+
+        def asset_paths
+          @asset_paths ||= Sprockets::Helpers::RailsHelper::AssetPaths.new ::Rails.application.config.action_controller, nil
+        end
+
+        # These use the sprockets helpers:
+        def http_font_path source
+          asset_paths.compute_public_path(source, 'fonts')
+        end
+
+        def http_image_path source
+          asset_paths.compute_public_path(source, 'images')
+        end
+
+        def http_javascript_path source
+          asset_paths.compute_public_path(source, 'javascripts')
+        end
+
+        def http_stylesheet_path source
+          asset_paths.compute_public_path(source, 'stylesheets')
+        end
       end
 
       module ConfigurationDefaults

--- a/lib/compass/app_integration/rails/configuration_defaults.rb
+++ b/lib/compass/app_integration/rails/configuration_defaults.rb
@@ -21,6 +21,17 @@ module Compass
         def default_javascripts_dir
           File.join("app", "assets", "javascripts")
         end
+
+        # Everything is now overlaid and served from the assets path
+
+        def default_http_assets_path
+          "#{top_level.http_path}assets"
+        end
+
+        alias default_http_images_path default_http_assets_path
+        alias default_http_javascripts_path default_http_assets_path
+        alias default_http_fonts_path default_http_assets_path
+        alias default_http_stylesheets_path default_http_assets_path
       end
 
       module ConfigurationDefaults


### PR DESCRIPTION
Guinea-pigging compass on Rails 3.1, noticed image helpers like replace-text didn't work as expected. They find the images on-disk in the right place, but aren't serving the right URLs.

Modfied Rails 3.1 default configuration to set all the HTTP paths to the asset http path. It should actually change depending on the asset pipeline's settings, really, like whether assets are being served from a different host.

Cheers!
