### PR TITLE
Update Gemfile to use rake 0.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'mocha'
 gem 'timecop'
 gem 'diff-lcs', '~> 1.1.2'
 
+gem 'rake', '0.8.7'
+
 group :mac do
   gem "rb-fsevent"
 end


### PR DESCRIPTION
rake 0.9.x won't be compatible with Cucumber::Rake::Task::ForkedCucumberRunner which uses the RUBY constant, resulting in 'uninitialized constant Cucumber::Rake::Task::ForkedCucumberRunner::RUBY'

This change also will be required to keep Compass green on Travis CI.
