### PR TITLE
Configurable output path for sprites

### DIFF
--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -1,10 +1,12 @@
 module Compass
   module Configuration
 
-    def self.attributes_for_directory(dir_name, http_dir_name = dir_name)
+    def self.attributes_for_directory(dir_name, http_dir_name = dir_name, output = false)
       [
         "#{dir_name}_dir",
         "#{dir_name}_path",
+        ("output_#{dir_name}_dir" if output),
+        ("output_#{dir_name}_path" if output),
         ("http_#{http_dir_name}_dir" if http_dir_name),
         ("http_#{http_dir_name}_path" if http_dir_name)
       ].compact.map{|a| a.to_sym}
@@ -15,11 +17,12 @@ module Compass
       :project_type,
       # Where is the project?
       :project_path,
+      :output_path,
       :http_path,
       # Where are the various bits of the project
       attributes_for_directory(:css, :stylesheets),
       attributes_for_directory(:sass, nil),
-      attributes_for_directory(:images),
+      attributes_for_directory(:images, :images, true),
       attributes_for_directory(:javascripts),
       attributes_for_directory(:fonts),
       attributes_for_directory(:extensions, nil),

--- a/lib/compass/configuration/defaults.rb
+++ b/lib/compass/configuration/defaults.rb
@@ -6,6 +6,10 @@ module Compass
         "."
       end
 
+      def default_output_path
+        top_level.project_path
+      end
+
       def default_project_type
         :stand_alone
       end
@@ -121,6 +125,18 @@ module Compass
         http_root_relative top_level.http_javascripts_dir
       end
 
+
+      def default_output_images_dir
+        top_level.images_dir || "images"
+      end
+
+      def default_output_images_path
+        if (op = top_level.output_path) && (dir = top_level.output_images_dir)
+          Compass.projectize(dir, op)
+        end
+      end
+
+
       def default_cache
         true
       end
@@ -136,7 +152,7 @@ module Compass
       def default_chunky_png_options
         {:compression => Zlib::BEST_COMPRESSION}
       end
-      
+
       # helper functions
 
       def http_join(*segments)

--- a/lib/compass/sass_extensions/sprites/sprite_methods.rb
+++ b/lib/compass/sass_extensions/sprites/sprite_methods.rb
@@ -43,7 +43,7 @@ module Compass
 
         # The on-the-disk filename of the sprite
         def filename
-          File.join(Compass.configuration.images_path, "#{path}-s#{uniqueness_hash}.png")
+          File.join(Compass.configuration.output_images_path, "#{path}-s#{uniqueness_hash}.png")
         end
 
         # Generate a sprite image if necessary

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -12,7 +12,7 @@ class SpritesTest < Test::Unit::TestCase
     @images_src_path = File.join(File.dirname(__FILE__), '..', 'fixtures', 'sprites', 'public', 'images')
     @images_tmp_path = File.join(File.dirname(__FILE__), '..', 'fixtures', 'sprites', 'public', 'images-tmp')
     ::FileUtils.cp_r @images_src_path, @images_tmp_path
-    file = StringIO.new("images_path = #{@images_tmp_path.inspect}\n")
+    file = StringIO.new("images_path = #{@images_tmp_path.inspect}\noutput_images_path = #{@images_tmp_path.inspect}\n")
     Compass.add_configuration(file, "sprite_config")
     Compass.configure_sass_plugin!
   end

--- a/test/units/sprites/sprite_command_test.rb
+++ b/test/units/sprites/sprite_command_test.rb
@@ -25,6 +25,7 @@ class SpriteCommandTest < Test::Unit::TestCase
   def config_data
     return <<-CONFIG
       images_path = #{@images_tmp_path.inspect}
+      output_images_path = #{@images_tmp_path.inspect}
     CONFIG
   end
 

--- a/test/units/sprites/sprite_map_test.rb
+++ b/test/units/sprites/sprite_map_test.rb
@@ -7,9 +7,12 @@ class SpriteMapTest < Test::Unit::TestCase
     Hash.send(:include, Compass::SassExtensions::Functions::Sprites::VariableReader)
     @images_src_path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'sprites', 'public', 'images')
     @images_tmp_path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'sprites', 'public', 'images-tmp')
+    @images_tmp_output_path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'sprites', 'public', 'images-tmp-output')
     FileUtils.cp_r @images_src_path, @images_tmp_path
+    Dir.mkdir @images_tmp_output_path
     config = Compass::Configuration::Data.new('config')
     config.images_path = @images_tmp_path
+    config.output_images_path = @images_tmp_path
     Compass.add_configuration(config)
     Compass.configure_sass_plugin!
     @options = {'cleanup' => Sass::Script::Bool.new(true), 'layout' => Sass::Script::String.new('vertical')}
@@ -18,6 +21,7 @@ class SpriteMapTest < Test::Unit::TestCase
 
   def teardown
     FileUtils.rm_r @images_tmp_path
+    FileUtils.rm_r @images_tmp_output_path
     @base = nil
   end
   
@@ -68,6 +72,19 @@ class SpriteMapTest < Test::Unit::TestCase
   it "should generate sprite" do
     @base.generate
     assert File.exists?(@base.filename)
+    assert !@base.generation_required?
+    assert !@base.outdated?
+  end
+
+  it "should generate sprite in output folder" do
+    config = Compass::Configuration::Data.new('config')
+    config.images_path = @images_tmp_path
+    config.output_images_path = @images_tmp_output_path
+    Compass.add_configuration(config)
+    Compass.configure_sass_plugin!
+    @base.generate
+    assert File.exists?(@base.filename)
+    assert Regexp.new(Regexp.escape(@images_tmp_output_path)) =~ @base.filename
     assert !@base.generation_required?
     assert !@base.outdated?
   end


### PR DESCRIPTION
Add a configurable output path for images (specifically sprite maps) that can be distinct from the input path. This is mostly useful situations like nanoc, where the output is being assembled into a new directory incrementally.

All tests (including new one for new functionality) are passing.
