### PR TITLE
Removing -ms-filter as it drives IE9+ crazy. plus existing filter works a

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    compass (0.11.3.b352e8b)
+    compass (0.11.3.461a589)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.1)
@@ -145,6 +145,7 @@ DEPENDENCIES
   livereload
   mocha
   rails (~> 3.0.0.rc)
+  rake (= 0.8.7)
   rb-fsevent
   rcov
   rspec (~> 2.0.0)

--- a/frameworks/compass/stylesheets/compass/css3/_images.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_images.scss
@@ -83,10 +83,7 @@
 @mixin filter-gradient($start-color, $end-color, $orientation: vertical) {
   @include has-layout;
   $gradient-type: if($orientation == vertical, 0, 1);
-  @if $legacy-support-for-ie8 {
-    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(gradientType=#{$gradient-type}, startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}')";
-  }
-  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
+  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 or $legacy-support-for-ie8 {
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=#{$gradient-type}, startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}');
   }
 }

--- a/frameworks/compass/stylesheets/compass/css3/_opacity.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_opacity.scss
@@ -6,10 +6,7 @@
 //         A number between 0 and 1, where 0 is transparent and 1 is opaque.
 
 @mixin opacity($opacity) {
-  @if $legacy-support-for-ie8 {
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=#{round($opacity * 100)})";
-  }
-  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
+  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 or $legacy-support-for-ie8 {
     filter: unquote("progid:DXImageTransform.Microsoft.Alpha(Opacity=#{round($opacity * 100)})");
   }
   opacity: $opacity;

--- a/test/fixtures/stylesheets/compass/css/gradients.css
+++ b/test/fixtures/stylesheets/compass/css/gradients.css
@@ -565,15 +565,12 @@
 
 .ie-horizontal-filter {
   *zoom: 1;
-  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(gradientType=1, startColorstr='#FFFFFFFF', endColorstr='#FF000000')";
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=1, startColorstr='#FFFFFFFF', endColorstr='#FF000000'); }
 
 .ie-vertical-filter {
   *zoom: 1;
-  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FF000000')";
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#FF000000'); }
 
 .ie-alpha-filter {
   *zoom: 1;
-  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#00FFFFFF')";
   filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#FFFFFFFF', endColorstr='#00FFFFFF'); }

--- a/test/fixtures/stylesheets/compass/css/opacity.css
+++ b/test/fixtures/stylesheets/compass/css/opacity.css
@@ -1,4 +1,3 @@
 div {
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=20);
   opacity: 0.2; }


### PR DESCRIPTION
Removing -ms-filter as it drives IE9+ crazy. plus existing filter works anyway for IE9-

More documented here: https://github.com/paulirish/html5-boilerplate/pull/354 (also note http://css3please.com no longer serves `-ms-filter` with `filter`). 
