### PR TITLE
trivial documentation change

### DIFF
--- a/doc-src/content/reference/compass/helpers/display.haml
+++ b/doc-src/content/reference/compass/helpers/display.haml
@@ -21,7 +21,7 @@ documented_functions:
   .details
     %p
       The following display values exist and will return
-      the elements listed to the right.
+      the elements listed below the display value.
     %dl
       %dg.head
         %dt Display Value


### PR DESCRIPTION
 "to the right" doesn't make sense with how the page is laid out 

"listed below the display value" is a bit more relevant to the current documentation layout
