### PR TITLE
Delegate the stylesheet_saved callback to the stylesheet_updated callback of Sass

### DIFF
--- a/lib/compass/configuration/helpers.rb
+++ b/lib/compass/configuration/helpers.rb
@@ -67,7 +67,7 @@ module Compass
           end
         end
         unless @callbacks_loaded
-          Sass::Plugin.on_updating_stylesheet do |sass_file, css_file|
+          Sass::Plugin.on_stylesheet_updated do |sass_file, css_file|
             Compass.configuration.run_callback(:stylesheet_saved, css_file)
           end
           Sass::Plugin.on_compilation_error do |e, filename, css|


### PR DESCRIPTION
The stylesheet_saved callback expects the file to be written, whereas the currently used updating_stylesheet is called before writing the stylesheet. 

The stylesheet_updated callback has been added to Sass in order to fix this problem:

https://github.com/nex3/sass/pull/151

This change is necessary to ensure a consistent and expected behavior of the stylesheet_saved callback. Note that it is also invoked after writing the stylesheet in Compass::Compiler#compile: https://github.com/chriseppstein/compass/blob/stable/lib/compass/compiler.rb#L141
