### PR TITLE
Inline fonts weren't being base64 encoded.

### DIFF
--- a/lib/compass/sass_extensions/functions/inline_image.rb
+++ b/lib/compass/sass_extensions/functions/inline_image.rb
@@ -12,7 +12,7 @@ module Compass::SassExtensions::Functions::InlineImage
     while args.size > 0
       path = args.shift.value
       real_path = File.join(Compass.configuration.fonts_path, path)
-      url = "url('data:#{compute_mime_type(path)};base64,#{data(real_path)}')"
+      url = inline_image_string(data(real_path), compute_mime_type(path))
       files << "#{url} format('#{args.shift}')"
     end
     Sass::Script::String.new(files.join(", "))


### PR DESCRIPTION
Should close issue #477.

We might consider renaming the inline_image_string function to something more generic.
