### PR TITLE
Compass does not work with Rails 3.1 and the asset pipeline disabled

### DIFF
--- a/lib/compass/configuration/helpers.rb
+++ b/lib/compass/configuration/helpers.rb
@@ -78,6 +78,7 @@ module Compass
       end
 
       def configure_rails!(app)
+        return unless app.config.respond_to?(:sass)
         app.config.compass.to_sass_engine_options.each do |key, value|
           app.config.sass.send(:"#{key}=", value)
         end


### PR DESCRIPTION
Fixes issue #522
