### PR TITLE
3D Browsers list should be configurable

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_transform.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transform.scss
@@ -88,8 +88,19 @@ $default-skew-x      : 5deg                  !default;
 // The default y-angle for skewing
 $default-skew-y      : 5deg                  !default;
 
+// The default 2D supporting browsers list
+$default-support2d-moz: true;
+$default-support2d-webkit: true;
+$default-support2d-o: true;
+$default-support2d-ms: true;
+$default-support2d-khtml: false;
+
 // The default 3D supporting browsers list
-$default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
+$default-support3d-moz: false;
+$default-support3d-webkit: true;
+$default-support3d-o: false;
+$default-support3d-ms: false;
+$default-support3d-khtml: false;
 
 
 // **Transform-origin**
@@ -107,11 +118,11 @@ $default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
   $only3d: $only3d or -compass-list-size(-compass-list($origin)) > 2;
   @if $only3d {
     @include experimental(transform-origin, $origin,
-      $default-supporting3d-browsers
+      $default-support3d-moz, $default-support3d-webkit, $default-support3d-o, $default-support3d-ms, $default-support3d-khtml, official
     );
   } @else {
     @include experimental(transform-origin, $origin,
-      -moz, -webkit, -o, -ms, not -khtml, official
+      $default-support2d-moz, $default-support2d-webkit, $default-support2d-o, $default-support2d-ms, $default-support2d-khtml, official
     );
   }
 }
@@ -150,11 +161,11 @@ $default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
 ) {
   @if $only3d {
     @include experimental(transform, $transform,
-      $default-supporting3d-browsers
+      $default-support3d-moz, $default-support3d-webkit, $default-support3d-o, $default-support3d-ms, $default-support3d-khtml, official
     );
   } @else {
     @include experimental(transform, $transform,
-      -moz, -webkit, -o, -ms, not -khtml, official
+      $default-support2d-moz, $default-support2d-webkit, $default-support2d-o, $default-support2d-ms, $default-support2d-khtml, official
     );
   }
 }
@@ -182,7 +193,7 @@ $default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
 // values from 500 to 1000 are more-or-less "normal" - a good starting-point.
 @mixin perspective($p) {
   @include experimental(perspective, $p,
-    $default-supporting3d-browsers
+    $default-support3d-moz, $default-support3d-webkit, $default-support3d-o, $default-support3d-ms, $default-support3d-khtml, official
   );
 }
 
@@ -193,7 +204,7 @@ $default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
 // where the two arguments represent x/y coordinates
 @mixin perspective-origin($origin: 50%) {
   @include experimental(perspective-origin, $origin,
-    $default-supporting3d-browsers
+    $default-support3d-moz, $default-support3d-webkit, $default-support3d-o, $default-support3d-ms, $default-support3d-khtml, official
   );
 }
 
@@ -205,7 +216,7 @@ $default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
 // browsers default to `flat`, mixin defaults to `preserve-3d`
 @mixin transform-style($style: preserve-3d) {
   @include experimental(transform-style, $style,
-    $default-supporting3d-browsers
+    $default-support3d-moz, $default-support3d-webkit, $default-support3d-o, $default-support3d-ms, $default-support3d-khtml, official
   );
 }
 
@@ -217,7 +228,7 @@ $default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
 // browsers default to visible, mixin defaults to hidden
 @mixin backface-visibility($visibility: hidden) {
   @include experimental(backface-visibility, $visibility,
-    $default-supporting3d-browsers
+    $default-support3d-moz, $default-support3d-webkit, $default-support3d-o, $default-support3d-ms, $default-support3d-khtml, official
   );
 }
 

--- a/frameworks/compass/stylesheets/compass/css3/_transform.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transform.scss
@@ -9,7 +9,7 @@
 // to switch between the two support lists. The toggle defaults to 'false' (2D),
 // and also accepts 'true' (3D). Currently the lists are as follows:
 // 2D: Mozilla, Webkit, Opera, Official
-// 3D: Webkit, Official **(Only Safari Supports 3D perspective)**
+// 3D: Webkit, Official **(Only Safari Supports 3D perspective)** <== This will be false soon
 
 // Available Transforms ------------------------------------------------------
 // - Scale (2d and 3d)
@@ -88,6 +88,9 @@ $default-skew-x      : 5deg                  !default;
 // The default y-angle for skewing
 $default-skew-y      : 5deg                  !default;
 
+// The default 3D supporting browsers list
+$default-supporting3d-browsers: -moz, -webkit, -o, -ms, not -khtml, official;
+
 
 // **Transform-origin**
 // Transform-origin sent as a complete string
@@ -104,7 +107,7 @@ $default-skew-y      : 5deg                  !default;
   $only3d: $only3d or -compass-list-size(-compass-list($origin)) > 2;
   @if $only3d {
     @include experimental(transform-origin, $origin,
-      not -moz, -webkit, not -o, not -ms, not -khtml, official
+      $default-supporting3d-browsers
     );
   } @else {
     @include experimental(transform-origin, $origin,
@@ -147,7 +150,7 @@ $default-skew-y      : 5deg                  !default;
 ) {
   @if $only3d {
     @include experimental(transform, $transform,
-      not -moz, -webkit, not -o, not -ms, not -khtml, official
+      $default-supporting3d-browsers
     );
   } @else {
     @include experimental(transform, $transform,
@@ -179,7 +182,7 @@ $default-skew-y      : 5deg                  !default;
 // values from 500 to 1000 are more-or-less "normal" - a good starting-point.
 @mixin perspective($p) {
   @include experimental(perspective, $p,
-    not -moz, -webkit, not -o, not -ms, not -khtml, official
+    $default-supporting3d-browsers
   );
 }
 
@@ -190,7 +193,7 @@ $default-skew-y      : 5deg                  !default;
 // where the two arguments represent x/y coordinates
 @mixin perspective-origin($origin: 50%) {
   @include experimental(perspective-origin, $origin,
-    not -moz, -webkit, not -o, not -ms, not -khtml, official
+    $default-supporting3d-browsers
   );
 }
 
@@ -202,7 +205,7 @@ $default-skew-y      : 5deg                  !default;
 // browsers default to `flat`, mixin defaults to `preserve-3d`
 @mixin transform-style($style: preserve-3d) {
   @include experimental(transform-style, $style,
-    not -moz, -webkit, not -o, not -ms, not -khtml, official
+    $default-supporting3d-browsers
   );
 }
 
@@ -214,7 +217,7 @@ $default-skew-y      : 5deg                  !default;
 // browsers default to visible, mixin defaults to hidden
 @mixin backface-visibility($visibility: hidden) {
   @include experimental(backface-visibility, $visibility,
-    not -moz, -webkit, not -o, not -ms, not -khtml, official
+    $default-supporting3d-browsers
   );
 }
 


### PR DESCRIPTION
Hi,

I heard that Firefox will soon support 3d transforms and one day IE & Opera also will. So instead of having 3d supporting vendors prefixes inside mixins I added them as a variable and used it to apply-origine, transform, perspective, etc...

I'm sorry I don't have much time for testing but so far it works great for me.

Thanks

Julien
