### PR TITLE
Clean up Compass::SpriteImporter.

### DIFF
--- a/lib/compass/commands/sprite.rb
+++ b/lib/compass/commands/sprite.rb
@@ -39,10 +39,11 @@ module Compass
 
       def perform
         relative_uri = options[:uri].gsub(/^#{Compass.configuration.images_dir}\//, '')
-        sprites = Compass::SpriteImporter.new(:uri => relative_uri, :options => Compass.sass_engine_options)
+        sprites = Compass::SpriteImporter.new
+        path, name = sprites.path_and_name(relative_uri)
         options[:output_file] ||= File.join(Compass.configuration.sass_path, "sprites", "_#{sprites.name}.#{Compass.configuration.preferred_syntax}")
         options[:skip_overrides] ||= false
-        contents = sprites.content_for_images(options[:skip_overrides])
+        contents = sprites.content_for_images(relative_uri, options[:skip_overrides])
         if options[:output_file][-4..-1] != "scss"
           contents = Sass::Engine.new(contents, Compass.sass_engine_options.merge(:syntax => :scss)).to_tree.to_sass
         end

--- a/lib/compass/sass_extensions/sprites/sprite_map.rb
+++ b/lib/compass/sass_extensions/sprites/sprite_map.rb
@@ -12,11 +12,13 @@ module Compass
         # Initialize a new sprite object from a relative file path
         # the path is relative to the <tt>images_path</tt> confguration option
         def self.from_uri(uri, context, kwargs)
-          importer = ::Compass::SpriteImporter.new(:uri => uri.value, :options => {})
-          sprites = importer.files.map do |sprite|
+          uri = uri.value
+          importer = ::Compass::SpriteImporter.new
+          path, name = importer.path_and_name(uri)
+          sprites = importer.files(uri).map do |sprite|
             sprite.gsub(Compass.configuration.images_path+"/", "")
           end
-          new(sprites, importer.path, importer.name, context, kwargs)
+          new(sprites, path, name, context, kwargs)
         end
 
         def initialize(sprites, path, name, context, kwargs)

--- a/test/units/sprites/image_test.rb
+++ b/test/units/sprites/image_test.rb
@@ -19,8 +19,10 @@ class SpritesImageTest < Test::Unit::TestCase
   let(:sprite_name) { File.basename(sprite_filename, '.png') }
   
   def parent
-    importer = Compass::SpriteImporter.new(:uri => "selectors/*.png", :options => options)
-    @parent ||= Compass::SassExtensions::Sprites::SpriteMap.new(importer.sprite_names.map{|n| "selectors/#{n}.png"}, importer.path, importer.name, importer.sass_engine, importer.options)
+    uri = "selectors/*.png"
+    importer = Compass::SpriteImporter.new
+    path, name = importer.path_and_name(uri)
+    @parent ||= Compass::SassExtensions::Sprites::SpriteMap.new(importer.sprite_names(uri).map{|n| "selectors/#{n}.png"}, path, name, importer.sass_engine(uri, options), options)
   end
   
   let(:options) do

--- a/test/units/sprites/importer_test.rb
+++ b/test/units/sprites/importer_test.rb
@@ -7,7 +7,7 @@ class ImporterTest < Test::Unit::TestCase
     @images_src_path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'sprites', 'public', 'images')
     file = StringIO.new("images_path = #{@images_src_path.inspect}\n")
     Compass.add_configuration(file, "sprite_config")
-    @importer = Compass::SpriteImporter.new(:uri => URI, :options => options)
+    @importer = Compass::SpriteImporter.new
   end
 
   def teardown
@@ -18,20 +18,12 @@ class ImporterTest < Test::Unit::TestCase
     {:foo => 'bar'}
   end
   
-  test "load should return an instance of SpriteImporter" do
-    assert Compass::SpriteImporter.load(URI, options).is_a?(Compass::SpriteImporter)
-  end
-  
-  test "name should return the sprite name" do
-    assert_equal 'selectors', @importer.name
-  end
-  
-  test "path should return the sprite path" do
-    assert_equal 'selectors', @importer.path
+  test "name should return the sprite path and name" do
+    assert_equal ['selectors', 'selectors'], @importer.path_and_name(URI)
   end
   
   test "should return all the sprite names" do
-    assert_equal ["ten-by-ten", "ten-by-ten_active", "ten-by-ten_hover", "ten-by-ten_target"], @importer.sprite_names
+    assert_equal ["ten-by-ten", "ten-by-ten_active", "ten-by-ten_hover", "ten-by-ten_target"], @importer.sprite_names(URI)
   end
   
   test "should have correct mtime" do
@@ -46,17 +38,13 @@ class ImporterTest < Test::Unit::TestCase
     assert @importer.find(URI, {}).is_a?(Sass::Engine)
   end
   
-  test "sass options should contain options" do
-    assert_equal 'bar', @importer.sass_options[:foo]
-  end
-  
   test "should fail given bad sprite extensions" do
     @images_src_path = File.join(File.dirname(__FILE__), '..', '..', 'fixtures', 'sprites', 'public', 'images')
     file = StringIO.new("images_path = #{@images_src_path.inspect}\n")
     Compass.add_configuration(file, "sprite_config")
-    importer = Compass::SpriteImporter.new(:uri => 'bad_extensions/*.jpg', :options => options)
+    importer = Compass::SpriteImporter.new
     begin
-      importer.sass_engine
+      importer.sass_engine('bad_extensions/*.jpg', options)
       assert false, "An invalid sprite file made it past validation."
     rescue Compass::Error => e
       assert e.message.include?('.png')

--- a/test/units/sprites/sprite_map_test.rb
+++ b/test/units/sprites/sprite_map_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class SpriteMapTest < Test::Unit::TestCase
+  URI = "selectors/*.png"
   
   def setup
     Hash.send(:include, Compass::SassExtensions::Functions::Sprites::VariableReader)
@@ -16,8 +17,9 @@ class SpriteMapTest < Test::Unit::TestCase
   end
   
   def setup_map
-    @importer = Compass::SpriteImporter.new(:uri => "selectors/*.png", :options => @options)
-    @base = Compass::SassExtensions::Sprites::SpriteMap.new(@importer.sprite_names.map{|n| "selectors/#{n}.png"}, @importer.path, @importer.name, @importer.sass_engine, @importer.options)
+    @importer = Compass::SpriteImporter.new
+    path, name = @importer.path_and_name(URI)
+    @base = Compass::SassExtensions::Sprites::SpriteMap.new(@importer.sprite_names(URI).map{|n| "selectors/#{n}.png"}, path, name, @importer.sass_engine(URI, @options), @options)
   end
 
   def teardown
@@ -29,7 +31,7 @@ class SpriteMapTest < Test::Unit::TestCase
   end
   
   it "should have the sprite names" do
-    assert_equal @importer.sprite_names, @base.sprite_names
+    assert_equal @importer.sprite_names(URI), @base.sprite_names
   end
   
   it 'should have image filenames' do


### PR DESCRIPTION
The main functional changes here are:

1) Making the :filename option on the generated CSS files of a format that is
   acceptable for SpriteImporter#find.
2) Making #find_relative return nil, since there are never relative imports
   within a generated stylesheet.

This change also brings the structure of SpriteImporter more inline with its
intended use. Instance variables such as @url and @options don't make sense,
since the same instance is used to import every sprite stylesheet; now these
variables are local and passed from function to function.

This change (specifically functional change 1 above) should also fix issue
sass#114.
