### PR TITLE
fixes a bug on Windows systems

### DIFF
--- a/lib/compass/compiler.rb
+++ b/lib/compass/compiler.rb
@@ -32,7 +32,7 @@ module Compass
     end
 
     def stylesheet_name(sass_file)
-      if sass_file.index(from) == 0
+      if sass_file.gsub(/\\/, '/').index(from) == 0
         sass_file[(from.length + 1)..-6]
       else
         raise Compass::Error, "You must compile individual stylesheets from the project directory."


### PR DESCRIPTION
There might be a better way to normalize file paths, but I don't know the code base well enough to propose it. 

This basically fixes cases where paths such as "C:\Users\Johannes" are compared vs "C:/Users/Johannes" which incorrectly results in the error being raised.
