### PR TITLE
Rubinius/JRuby sort fix

### DIFF
--- a/lib/compass/sass_extensions/sprites/row_fitter.rb
+++ b/lib/compass/sass_extensions/sprites/row_fitter.rb
@@ -10,7 +10,13 @@ module Compass
         def_delegators :rows, :[]
 
         def initialize(images)
-          @images = images.sort {|a,b| a.height <=> b.height }
+          @images = images.sort do |a,b|
+            if a.height == b.height
+              b.width <=> a.width
+            else
+              a.height <=> b.height
+            end
+          end
           @rows = []
         end
 

--- a/test/units/sprites/sprite_map_test.rb
+++ b/test/units/sprites/sprite_map_test.rb
@@ -111,7 +111,7 @@ class SpriteMapTest < Test::Unit::TestCase
     base.generate
     assert_equal 400, base.width
     assert_equal 60, base.height
-    assert_equal [[0, 0], [20, 120], [20, 20], [20, 0], [20, 160]], base.images.map {|i| [i.top, i.left]}
+    assert_equal [[0, 0], [20, 120], [20, 0], [20, 100], [20, 160]], base.images.map {|i| [i.top, i.left]}
     assert File.exists?(base.filename)
     FileUtils.rm base.filename
   end


### PR DESCRIPTION
Rubinius and JRuby were discovering images to be sorted in a different way than CRuby, causing a unit test to break when images with the same height were sorted. This change forces images with the same height to then be sorted by width, ensuring the same sort order in all Rubies.
