### PR TITLE
Added `sprite-replace-text` mixin

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -72,7 +72,6 @@ $disable-magic-sprite-selectors:false !default;
 @mixin sprite-replace-text ($map, $img-name){    
     @include hide-text;
     background: sprite($map, $img-name) no-repeat;
-    display: block;
     width: image-width(sprite-file($map, $img-name));
     height: image-height(sprite-file($map, $img-name));
 }

--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -64,3 +64,15 @@ $disable-magic-sprite-selectors:false !default;
     }
   }
 }
+
+// Similar to 'replace-text-with-dimensions' but with sprites
+// To use, create your sprite and then pass it in the `$map` param
+// The name of the image in the sprite folder should be `$img-name`
+
+@mixin sprite-replace-text ($map, $img-name){    
+    @include hide-text;
+    background: sprite($map, $img-name) no-repeat;
+    display: block;
+    width: image-width(sprite-file($map, $img-name));
+    height: image-height(sprite-file($map, $img-name));
+}

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -604,4 +604,36 @@ class SpritesTest < Test::Unit::TestCase
     CSS
   end
 
+  it "should replace text with images and dimensions using sprites"
+    css = render <<-SCSS
+    @import "imgs/*.png";
+    $sprite: sprite-map("imgs/*.png");
+    .myImg { 
+      @include sprite-replace-text($sprite, myImg); 
+    }
+    .yourImg {
+      @include sprite-replace-text($sprite, yourImg);
+    }
+    SCSS
+    assert_correct css, <<-CSS
+    .myImg {
+      text-indent: -119988px; 
+      overflow: hidden; 
+      text-align: left; 
+      background: url('imgs/imgs-s3020e82f52.png') 0 0 no-repeat; 
+      display: block; 
+      width: 26px; //whatever the dimensions are
+      height: 26px;
+    }
+    .yourImg {
+      text-indent: -119988px; 
+      overflow: hidden; 
+      text-align: left; 
+      background: url('imgs/imgs-s3020e82f52.png') 0 -26px no-repeat; //shifted
+      display: block; 
+      width: 26px; //whatever the dimensions are
+      height: 26px;
+    }
+    CSS
+  end
 end


### PR DESCRIPTION
Added `sprite-replace-text` mixin for replicating the `replace-text-with-dimensions` mixin using sprites.
