### PR TITLE
add group parameter to rails initializer to run on asset precompilation

### DIFF
--- a/lib/compass/app_integration/rails/actionpack3/railtie.rb
+++ b/lib/compass/app_integration/rails/actionpack3/railtie.rb
@@ -37,7 +37,7 @@ end
 
 module Compass
   class Railtie < Rails::Railtie
-    initializer "compass.initialize_rails" do |app|
+    initializer "compass.initialize_rails", :group => :assets do |app|
       # Configure compass for use within rails, and provide the project configuration
       # that came via the rails boot process.
       Compass::AppIntegration::Rails.initialize!(app.config.compass)


### PR DESCRIPTION
Hi there, asset precompilation task was [changed](https://github.com/rails/rails/commit/b4798894d35e2f1fbd53aad8cd230de154650339) in rails 3-1-stable branch. There is commit message:

To the app developer, this means configuration add in
config/initializers/\* will not be executed.

Plugins developers need to special case their initializers that are
meant to be run in the assets group by adding :group => :assets.

I have added this option.
