### PR TITLE
Fixed type conversion error on exit in bin/compass

### DIFF
--- a/bin/compass
+++ b/bin/compass
@@ -36,5 +36,7 @@ if ARGV.delete("--profile")
   printer.print(STDERR, 0)
   exit exit_code
 else
-  exit runner.call
+  exit_code = runner.call
+  exit 1 if exit_code == nil
+  exit exit_code
 end


### PR DESCRIPTION
I encountered this when using jruby and passing an illegal option.

```
[cdean@dhcp-1710-178 velodash]$ compass -L $GEM_HOME/gems/iphone-style-checkboxes-0.0.2 install iphone-style-checkboxesError: invalid option: -L
TypeError: no implicit conversion from nil to integer
    exit at org/jruby/RubyKernel.java:856
    exit at org/jruby/RubyKernel.java:836
  (root) at /Users/cdean/.rvm/gems/jruby-1.6.4@velodash/gems/compass-0.12.alpha.0/bin/compass:39
    load at org/jruby/RubyKernel.java:1073
  (root) at /Users/cdean/.rvm/gems/jruby-1.6.4@velodash/bin/compass:19
```

After fix:

```
[cdean@dhcp-1710-178 velodash]$ compass -L $GEM_HOME/gems/iphone-style-checkboxes-0.0.2 install iphone-style-checkboxes
Error: invalid option: -L
```
