### PR TITLE
Fix to remove prefix to -moz-user-select values

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
@@ -13,12 +13,7 @@
 
 @mixin user-select($select) {
   $select: unquote($select);
-  // Mozilla needs prefix on both the -moz-property and the -moz-value
-  @include experimental(user-select, -moz-#{$select},
-    -moz, not -webkit, not -o, not -ms, not -khtml, not official
-  );
-  // others do not
   @include experimental(user-select, $select,
-    not -moz, -webkit, not -o, not -ms, -khtml, official
+    -moz, -webkit, not -o, not -ms, -khtml, official
   );
 }

--- a/test/fixtures/stylesheets/compass/css/user-interface.css
+++ b/test/fixtures/stylesheets/compass/css/user-interface.css
@@ -1,5 +1,5 @@
 .user-select {
-  -moz-user-select: -moz-none;
+  -moz-user-select: none;
   -webkit-user-select: none;
   -khtml-user-select: none;
   user-select: none; }


### PR DESCRIPTION
As per discussion for the following patch, this fixes user-select behavior for Firefox:
chriseppstein/compass#509
