### PR TITLE
more attractive whitespace for prefixed and aligned styles

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_shared.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_shared.scss
@@ -5,34 +5,34 @@
 // the implementations are identical except for the property
 // prefix.
 @mixin experimental($property, $value,
-  $moz      : $experimental-support-for-mozilla,
   $webkit   : $experimental-support-for-webkit,
-  $o        : $experimental-support-for-opera,
-  $ms       : $experimental-support-for-microsoft,
   $khtml    : $experimental-support-for-khtml,
+  $moz      : $experimental-support-for-mozilla,
+  $ms       : $experimental-support-for-microsoft,
+  $o        : $experimental-support-for-opera,
   $official : true
 ) {
-  @if $moz     and $experimental-support-for-mozilla   {    -moz-#{$property} : $value; }
   @if $webkit  and $experimental-support-for-webkit    { -webkit-#{$property} : $value; }
-  @if $o       and $experimental-support-for-opera     {      -o-#{$property} : $value; }
-  @if $ms      and $experimental-support-for-microsoft {     -ms-#{$property} : $value; }
   @if $khtml   and $experimental-support-for-khtml     {  -khtml-#{$property} : $value; }
+  @if $moz     and $experimental-support-for-mozilla   {    -moz-#{$property} : $value; }
+  @if $ms      and $experimental-support-for-microsoft {     -ms-#{$property} : $value; }
+  @if $o       and $experimental-support-for-opera     {      -o-#{$property} : $value; }
   @if $official                                        {         #{$property} : $value; }
 }
 
 // Same as experimental(), but for cases when the property is the same and the value is vendorized
 @mixin experimental-value($property, $value,
-  $moz      : $experimental-support-for-mozilla,
   $webkit   : $experimental-support-for-webkit,
-  $o        : $experimental-support-for-opera,
-  $ms       : $experimental-support-for-microsoft,
   $khtml    : $experimental-support-for-khtml,
+  $moz      : $experimental-support-for-mozilla,
+  $ms       : $experimental-support-for-microsoft,
+  $o        : $experimental-support-for-opera,
   $official : true
 ) {
-  @if $moz     and $experimental-support-for-mozilla   { #{$property} :    -moz-#{$value}; }
   @if $webkit  and $experimental-support-for-webkit    { #{$property} : -webkit-#{$value}; }
-  @if $o       and $experimental-support-for-opera     { #{$property} :      -o-#{$value}; }
-  @if $ms      and $experimental-support-for-microsoft { #{$property} :     -ms-#{$value}; }
   @if $khtml   and $experimental-support-for-khtml     { #{$property} :  -khtml-#{$value}; }
+  @if $moz     and $experimental-support-for-mozilla   { #{$property} :    -moz-#{$value}; }
+  @if $ms      and $experimental-support-for-microsoft { #{$property} :     -ms-#{$value}; }
+  @if $o       and $experimental-support-for-opera     { #{$property} :      -o-#{$value}; }
   @if $official                                        { #{$property} :         #{$value}; }
 }


### PR DESCRIPTION
Here we take these aligned properties and values and order their prefixes to create a very nice visual waterfall.

So it's not only easy to look at as a group (as they are aligned), but attractive as well.

This approach is used on http://css3please.com/ and written by desandro at http://dropshado.ws/post/2054719546/css-formatting
