### PR TITLE
Use `transition` shorthand if appropriate

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_transition.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transition.scss
@@ -73,15 +73,42 @@ $default-transition-delay: false !default;
 // Transition all-in-one shorthand
 
 @mixin single-transition(
-  $properties: $default-transition-property,
+  $property: $default-transition-property,
   $duration: $default-transition-duration,
   $function: $default-transition-function,
   $delay: $default-transition-delay
 ) {
-  @include transition-property($properties);
-  @include transition-duration($duration);
-  @if $function { @include transition-timing-function($function); }
-  @if $delay { @include transition-delay($delay); }
+  @if $property and $duration and $function {
+    // Shorthand (see https://github.com/chriseppstein/compass/issues/585)
+    @if $delay {
+      -webkit-transition: $property $duration $function;
+      -webkit-transition-delay: $delay;
+      @include experimental(transition, $property $duration $function $delay,
+        -moz,
+        not -webkit,
+        -o,
+        not -ms,
+        not -khtml,
+        official
+      );
+    }
+    @else {
+      @include experimental(transition, $property $duration $function,
+        -moz,
+        -webkit,
+        -o,
+        not -ms,
+        not -khtml,
+        official
+      );
+    }
+  }
+  @else {
+    @include transition-property($property);
+    @include transition-duration($duration);
+    @if $function { @include transition-timing-function($function); }
+    @if $delay { @include transition-delay($delay); }
+  }
 }
 
 @mixin transition(

--- a/test/fixtures/stylesheets/compass/css/transition.css
+++ b/test/fixtures/stylesheets/compass/css/transition.css
@@ -1,0 +1,12 @@
+.single-transition-without-delay {
+  -moz-transition: all 0.6s ease-out;
+  -webkit-transition: all 0.6s ease-out;
+  -o-transition: all 0.6s ease-out;
+  transition: all 0.6s ease-out; }
+
+.single-transition-with-delay {
+  -webkit-transition: all 0.6s ease-out;
+  -webkit-transition-delay: 0.2s;
+  -moz-transition: all 0.6s ease-out 0.2s;
+  -o-transition: all 0.6s ease-out 0.2s;
+  transition: all 0.6s ease-out 0.2s; }

--- a/test/fixtures/stylesheets/compass/sass/transition.scss
+++ b/test/fixtures/stylesheets/compass/sass/transition.scss
@@ -1,0 +1,4 @@
+@import "compass/css3/transition";
+
+.single-transition-without-delay  { @include single-transition(all, 0.6s, ease-out); }
+.single-transition-with-delay     { @include single-transition(all, 0.6s, ease-out, 0.2s); }


### PR DESCRIPTION
This change addresses [#585](https://github.com/chriseppstein/compass/issues/585) in the manner that @paulirish suggested.

---

I've had quite a bit of difficulty running the test suite. Initially I made these changes on `stable` and was able to run the tests successfully (after patching one failing test). I then switched to `master`, applied the changes, and tried to run the tests again without success.

There's probably something wrong with my setup. When I run `rake run_tests` I get:

```
WARNING: no such file to load -- rcov/rcovtask
rake aborted!
```

On `stable` I was able to run the tests via `rake test`, but when I try that now on `master` I get `WARNING: DSL method Object#ruby` ad infinitum.

---

To summarize, I _think_ the patch is good, but I'd greatly appreciate some suggestions as to what I'm doing wrong so that I can confirm this to be the case.
