### PR TITLE
TypeError: can't convert Sprockets::StaticAsset into String

### DIFF
--- a/lib/compass/sass_extensions/functions/image_size.rb
+++ b/lib/compass/sass_extensions/functions/image_size.rb
@@ -15,6 +15,7 @@ module Compass::SassExtensions::Functions::ImageSize
 
   class ImageProperties
     def initialize(file)
+      file = file.to_path if file.kind_of? Sprockets::StaticAsset
       @file = file
       @file_type = File.extname(@file)[1..-1]
     end


### PR DESCRIPTION
So I got an error like:

TypeError: can't convert Sprockets::StaticAsset into String

While trying to serve css.  I'm not able to provide easy steps to reproduce. 

Included fix works for me, but you probably can understand better what is going on there, maybe these Sprockets::StaticAsset objects should not be getting there in the first place.
