### PR TITLE
Fix Railtie initialization when initialize_on_precompile is disabled

### DIFF
--- a/lib/compass/app_integration/rails/actionpack31/railtie.rb
+++ b/lib/compass/app_integration/rails/actionpack31/railtie.rb
@@ -76,7 +76,7 @@ end
 
 module Compass
   class Railtie < Rails::Railtie
-    initializer "compass.initialize_rails" do |app|
+    initializer "compass.initialize_rails", :group => :all do |app|
       # Configure compass for use within rails, and provide the project configuration
       # that came via the rails boot process.
       Compass::AppIntegration::Rails.check_for_double_boot!


### PR DESCRIPTION
Heya,
Rails 3.1.1 adds config.assets.initialize_on_precompile, which can be set to false to avoid initializing the entire application environment.

This commit tells Rails that it's necessary to initialize compass even when initialize_on_precompile is false.

Any thoughts?
