### PR TITLE
Handle Rails adding methods to nil that it really shouldn't.

### DIFF
--- a/lib/compass/configuration/inheritance.rb
+++ b/lib/compass/configuration/inheritance.rb
@@ -137,6 +137,8 @@ module Compass
         def read_without_default(attribute)
           if set?(attribute)
             send("raw_#{attribute}")
+          elsif inherited_data.nil?
+            nil
           elsif inherited_data.respond_to?("#{attribute}_without_default")
             inherited_data.send("#{attribute}_without_default")
           elsif inherited_data.respond_to?(attribute)


### PR DESCRIPTION
This might only affect Rails 2, but it shouldn't hurt elsewhere (all tests pass).

The issue is that Rails is mixing in a [#cache](https://github.com/rails/rails/blob/v2.3.11/actionpack/lib/action_view/helpers/cache_helper.rb) so globally that nil.respond_to?(:cache) is true, but this method doesn't make sense to call from outside a request (in my case, from a rake task).
