### PR TITLE
fixing total sprite width for repeat-x images

### DIFF
--- a/lib/compass/sass_extensions/sprites/sprite_methods.rb
+++ b/lib/compass/sass_extensions/sprites/sprite_methods.rb
@@ -1,3 +1,5 @@
+require 'rational'
+
 module Compass
   module SassExtensions
     module Sprites
@@ -27,11 +29,15 @@ module Compass
         
         # Creates the Sprite::Image objects for each image and calculates the width
         def init_images
+          repeated_widths = []
           @images = image_names.collect do |relative_file|
             image = Compass::SassExtensions::Sprites::Image.new(self, relative_file, kwargs)
+            repeated_widths << image.width if image.repeat == 'repeat-x'
             @width = [ @width, image.width + image.offset ].max
             image
           end
+          lcm = repeated_widths.inject {|l, w| l.lcm(w)}
+          @width += @width % lcm if lcm
         end
         
         # Calculates the overal image dimensions


### PR DESCRIPTION
It is related to the issue #296. I calculate lowest common multiple for all repeat-x images in the sprite and then correct calculated @width, so that it divides by lcm without reminder.
