### PR TITLE
remove less files, when cleaning up old sprites

### DIFF
--- a/lib/compass/sass_extensions/sprites/sprite_methods.rb
+++ b/lib/compass/sass_extensions/sprites/sprite_methods.rb
@@ -72,7 +72,7 @@ module Compass
         end
         
         def cleanup_old_sprites
-          Dir[File.join(Compass.configuration.images_path, "#{path}-*.png")].each do |file|
+          Dir[File.join(Compass.configuration.images_path, "#{path}-s*.png")].each do |file|
             FileUtils.rm file
           end
         end


### PR DESCRIPTION
(fixes deleting to many generated sprites in some cases)

fix for issue #647

(This is my first issue and pull request on github, I hope everything is correct :) )
