### PR TITLE
Correctly detect if the assets pipeline is enabled.

### DIFF
--- a/lib/compass/app_integration/rails.rb
+++ b/lib/compass/app_integration/rails.rb
@@ -26,7 +26,7 @@ module Compass
       def configuration
         config = Compass::Configuration::Data.new('rails')
         config.extend(ConfigurationDefaults)
-        config.extend(ConfigurationDefaultsWithAssetPipeline) if Sass::Util.ap_geq?('3.1.0') || Sass::Util.ap_geq?('3.1.0.rc') || Sass::Util.ap_geq?('3.1.0.beta')
+        config.extend(ConfigurationDefaultsWithAssetPipeline) if (Sass::Util.ap_geq?('3.1.0') || Sass::Util.ap_geq?('3.1.0.rc') || Sass::Util.ap_geq?('3.1.0.beta')) && assets_pipeline_enabled?
         config
       end
 
@@ -62,6 +62,11 @@ module Compass
         unless Sass::Util.ap_geq?('3.1.0.beta')
           defined?(Sass::Plugin) && !Sass::Plugin.options[:never_update]
         end
+      end
+
+      def assets_pipeline_enabled?
+        rails_config = ::Rails.application.config
+        rails_config.respond_to?(:assets) && rails_config.assets.try(:enabled)
       end
 
       def rails_compilation_enabled?


### PR DESCRIPTION
I've got the same error of issue #634.
In my case, the problem was that compass included `ConfigurationDefaultsWithAssetPipeline` even if in `config/application.rb` I set 

``` ruby
config.assets.enabled = false
```

I modified the condition by adding an additional method which detect if the assets pipeline is enabled.

Hope this helps!
   Shogun
