### PR TITLE
Fix wrong degree to radian conversion in trig function. Might break some...

### DIFF
--- a/lib/compass/sass_extensions/functions/trig.rb
+++ b/lib/compass/sass_extensions/functions/trig.rb
@@ -19,7 +19,7 @@ module Compass::SassExtensions::Functions::Trig
   private
   def trig(operation, number)
     if number.numerator_units == ["deg"] && number.denominator_units == []
-      Sass::Script::Number.new(Math.send(operation, Math::PI * number.value / 360))
+      Sass::Script::Number.new(Math.send(operation, Math::PI * number.value / 180))
     else
       Sass::Script::Number.new(Math.send(operation, number.value), number.numerator_units, number.denominator_units)
     end


### PR DESCRIPTION
When passing degrees to a trig function, the angle is halved because of a wrong denominator (360 instead of 180) while converting from degrees to radians. See http://www.teacherschoice.com.au/maths_library/angles/angles.htm . Some have worked around this by just doubling their angles, so this change might break that workaround.
