### PR TITLE
Fix typos, broken external link

### DIFF
--- a/doc-src/content/help/tutorials/contributing.markdown
+++ b/doc-src/content/help/tutorials/contributing.markdown
@@ -10,10 +10,10 @@ Contributing Stylesheets to Compass
 
 Thank you for your interest in contributing to Compass. Our goal is to make it as easy
 as we can for you to contribute changes to compass -- So if there's something here that
-seems harder than it aught to be, please let us know.
+seems harder than it ought to be, please let us know.
 
 If you find a bug **in this document**, you are bound to contribute a fix. Stop reading now
-if you do not wish to abide by this rool.
+if you do not wish to abide by this rule.
 
 **Step 1**: If you do not have a github account, create one.
 

--- a/doc-src/content/reference/compass/helpers/colors.haml
+++ b/doc-src/content/reference/compass/helpers/colors.haml
@@ -18,7 +18,7 @@ documented_functions:
 %p
   These color functions are useful for creating generic libraries that have to accept a
   range of inputs. For more color functions see
-  <a href="http://sass-lang.com/yardoc/Sass/Script/Functions.html">the sass reference
+  <a href="http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html">the sass reference
   documentation</a>
 
 #adjust-lightness.helper


### PR DESCRIPTION
There are a couple of typos in '…help/tutorials/contributing/' that appear intentional. But in the spirit of the document, I've fixed them here.

Also, a broken link to the Sass color functions documentation is fixed in '…reference/compass/helpers/colors/'.
