### PR TITLE
Flush stdout buffer to make sure the stdout message show up correctly.

### DIFF
--- a/lib/compass/commands/watch_project.rb
+++ b/lib/compass/commands/watch_project.rb
@@ -81,6 +81,7 @@ module Compass
         action = FSSM::Backends::Default.to_s == "FSSM::Backends::Polling" ? "polling" : "watching"
 
         puts ">>> Compass is #{action} for changes. Press Ctrl-C to Stop."
+        $stdout.flush
 
         begin
         FSSM.monitor do |monitor|
@@ -100,14 +101,17 @@ module Compass
               path.glob glob
               path.update do |base, relative|
                 puts ">>> Change detected to: #{relative}"
+                $stdout.flush
                 callback.call(base, relative)
               end
               path.create do |base, relative|
                 puts ">>> New file detected: #{relative}"
+                $stdout.flush
                 callback.call(base, relative)
               end
               path.delete do |base, relative|
                 puts ">>> File Removed: #{relative}"
+                $stdout.flush
                 callback.call(base, relative)
               end
             end
@@ -139,6 +143,7 @@ module Compass
         if file = compiler.out_of_date?
           begin
             puts ">>> Change detected to: #{relative || compiler.relative_stylesheet_name(file)}"
+            $stdout.flush
             compiler.run
             GC.start
           rescue StandardError => e


### PR DESCRIPTION
Not sure if that's the correct way of handling the problem, but I've certainly could reproduce it (by having a supervisor conf with a `compass watch .` program configured).

Issue #619 has probably a better explanation.
