### PR TITLE
Modified "background" property to be "background-image"

### DIFF
--- a/lib/compass/sprite_importer.rb
+++ b/lib/compass/sprite_importer.rb
@@ -140,7 +140,8 @@ $#{name}-clean-up: true !default;
 // All sprites should extend this class
 // The #{name}-sprite mixin will do so for you.
 \#{$#{name}-sprite-base-class} {
-  background: $#{name}-sprites no-repeat;
+  background-image: $#{name}-sprites;
+  background-repeat: no-repeat;
 }
 
 // Use this to set the dimensions of an element


### PR DESCRIPTION
I had sprites with transparency that I used throughout the website, using different background-colors in different places, specially with :hover and :active selectors. The current implementation of the sprite helper used "background: $sprite no-repeat" which was overriding my background-color property; I changed it to:
background-image:$sprite, background-repeat:no-repeat, which allows more granular setting-up of the background property.
