### PR TITLE
Fixed syntax error in Growl example code so it runs on copy and paste.

### DIFF
--- a/doc-src/content/help/tutorials/configuration-reference.markdown
+++ b/doc-src/content/help/tutorials/configuration-reference.markdown
@@ -383,7 +383,7 @@ to avoid crashing the watcher in the case where the file has been removed.
 
     on_stylesheet_saved do |filename|
       Growl.notify {
-         self.message "#{File.basename(filename)} updated!"
+         self.message = "#{File.basename(filename)} updated!"
          self.icon = '/path/to/success.jpg'
        }
     end


### PR DESCRIPTION
A tiny, tiny error that caught me unawares…
