### PR TITLE
Load sprites base

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/_sprites.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/_sprites.scss
@@ -1,1 +1,2 @@
+@import "sprites/base";
 @import "sprites/sprite-img";


### PR DESCRIPTION
The scss in `compass/utilities/sprites` does not load `sprites/base`. This patch fixes that.

Now we can now do :

```
@import "compass/utilities/sprites";
```

Instead of :

```
@import "compass/utilities/sprites/base";
@import "compass/utilities/sprites/sprites";
```
