### PR TITLE
Add compass and blueprint to Sass load_path

### DIFF
--- a/lib/compass.rb
+++ b/lib/compass.rb
@@ -33,3 +33,9 @@ end
 
 # for rails upgrade warnings in 0.12
 require 'compass/app_integration/rails'
+
+# append compass stylesheets to Sass load path by default
+Sass::Engine::DEFAULT_OPTIONS[:load_paths].tap do |load_paths|
+  load_paths << File.expand_path "../../frameworks/compass/stylesheets", __FILE__
+  load_paths << File.expand_path "../../frameworks/blueprint/stylesheets", __FILE__
+end


### PR DESCRIPTION
Following from the discussion of on [this sprockets ticket](https://github.com/sstephenson/sprockets/issues/283), Compass does not add itself to Sass's load path by default.

I'm trying to use Compass standalone and `@import compass` without specifying a config file and having Sprockets and Sass do the compilation. Since compass isn't on the load path, I have to manually add it. Seeing how compass depends on sass, I thought it'd be simpler if compass appends itself to sass's load path by default.  I've attached a sample code snippet that does this.

Do you think this is a good idea? If so, I can add a test for the attached code.
