### PR TITLE
Fix link to partials in docs (help/tutorials/best_practices)

### DIFF
--- a/doc-src/content/help/tutorials/best_practices.markdown
+++ b/doc-src/content/help/tutorials/best_practices.markdown
@@ -107,7 +107,7 @@ For instance, don't use `table thead tr th` when a simple `th` selector will
 suffice. This might mean that you have to separate your styles into several
 selectors and let the document cascade work to your advantage.
 
-[1]: http://sass-lang.com/yardoc/file.SASS_REFERENCE.html#partials
+[1]: http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#partials
 [2]: http://groups.google.com/group/compass-users/browse_frm/thread/0ed216d409476f88
 [3]: http://compass-style.org/help/tutorials/configurable-variables/
 [4]: http://c2.com/cgi/wiki?DontRepeatYourself


### PR DESCRIPTION
vovambo on the Compass Google group points out a broken link in the docs:
https://groups.google.com/forum/?fromgroups#!topic/compass-users/d4yhGBpXBzw
