### PR TITLE
Refactor hide-text

### DIFF
--- a/doc-src/content/stylesheets/partials/_home.scss
+++ b/doc-src/content/stylesheets/partials/_home.scss
@@ -4,7 +4,8 @@ body#home {
   h1#logo {
     $logo: 'compass-logo.png';
     background: image-url($logo) no-repeat;
-    text-indent: -9999px;
+    text-indent: 100%;
+    white-space: nowrap;
     overflow: hidden;
     width: image-width($logo);
     height: image-height($logo)/2;

--- a/doc-src/content/stylesheets/partials/_home.scss
+++ b/doc-src/content/stylesheets/partials/_home.scss
@@ -4,7 +4,7 @@ body#home {
   h1#logo {
     $logo: 'compass-logo.png';
     background: image-url($logo) no-repeat;
-    text-indent: 100%;
+    text-indent: 150%;
     white-space: nowrap;
     overflow: hidden;
     width: image-width($logo);

--- a/doc-src/content/stylesheets/partials/_main.scss
+++ b/doc-src/content/stylesheets/partials/_main.scss
@@ -38,7 +38,7 @@ footer {
   margin-top: 1.5em;
 }
 h2 a.help {
-  text-indent: 100%;
+  text-indent: 150%;
   white-space: nowrap;
   overflow: hidden;
   display: inline-block;

--- a/doc-src/content/stylesheets/partials/_main.scss
+++ b/doc-src/content/stylesheets/partials/_main.scss
@@ -38,7 +38,9 @@ footer {
   margin-top: 1.5em;
 }
 h2 a.help {
-  text-indent: -9999px;
+  text-indent: 100%;
+  white-space: nowrap;
+  overflow: hidden;
   display: inline-block;
   position: relative;
   text-decoration: none;

--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -26,9 +26,7 @@
 
 // Hides text in an element so you can see the background.
 @mixin hide-text {
-  $approximate_em_value: 12px / 1em;
-  $wider_than_any_screen: -9999em;
-  text-indent: $wider_than_any_screen * $approximate_em_value;
-  overflow: hidden;
-  text-align: left;
+  text-indent: 100%; // Indent just enough to push an element out of view
+  white-space: nowrap; // Makes sure the lines don't wrap back into view
+  overflow: hidden; // hides overflow
 }

--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -26,7 +26,7 @@
 
 // Hides text in an element so you can see the background.
 @mixin hide-text {
-  text-indent: 100%; // Indent just enough to push an element out of view
+  text-indent: 150%; // Indent just enough to push an element out of view
   white-space: nowrap; // Makes sure the lines don't wrap back into view
   overflow: hidden; // hides overflow
 }


### PR DESCRIPTION
This fixes two major issues with the -9999px indent. With this method
the text is always flowing away from the container so there is no risk
of it flowing into view. Also it prevents a 9999px box from being
rendered by the browser saving tons of video memory and making things
faster ( see http://youtu.be/xuMWhto62Eo )
