### PR TITLE
Update with Kellum Method _replacement.scss

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -25,10 +25,9 @@
 }
 
 // Hides text in an element so you can see the background.
+// Kellum Method improves performance. http://bit.ly/Aazp14
 @mixin hide-text {
-  $approximate_em_value: 12px / 1em;
-  $wider_than_any_screen: -9999em;
-  text-indent: $wider_than_any_screen * $approximate_em_value;
-  overflow: hidden;
-  text-align: left;
+ text-indent: 100%;
+ white-space: nowrap;
+ overflow: hidden;
 }


### PR DESCRIPTION
Replace the -9999px Hack with the Kellum Method http://bit.ly/Aazp14
• Really long strings of text will never flow into the container because they always flow away from the container.
• Performance is dramatically improved because a 9999px box is not drawn. Noticeably so in animations on the iPad 1.
