### PR TITLE
How Compass could use Scott Kellum's updated Image Replacement

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -8,7 +8,7 @@
 // * `x` -- the x position of the background image.
 // * `y` -- the y position of the background image.
 @mixin replace-text($img, $x: 50%, $y: 50%) {
-  @include hide-text;
+  @extend .hide-text;
   background: {
     image: image-url($img);
     repeat: no-repeat;
@@ -25,10 +25,8 @@
 }
 
 // Hides text in an element so you can see the background.
-@mixin hide-text {
-  $approximate_em_value: 12px / 1em;
-  $wider_than_any_screen: -9999em;
-  text-indent: $wider_than_any_screen * $approximate_em_value;
+.hide-text {
+  text-indent: 100%;
+  white-space: nowrap;
   overflow: hidden;
-  text-align: left;
 }


### PR DESCRIPTION
See Zeldman: http://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/

The new method improves browser performance.

Made hide-text an @extend rather than a @mixin to help keep the compiled CSS lighter. You might want to keep it as a mix-in, but what's a mixin without variables if not a bulky @extend?
