### PR TITLE
Add .eot (Embedded OpenType) to fonts format

### DIFF
--- a/lib/compass/installers/manifest.rb
+++ b/lib/compass/installers/manifest.rb
@@ -49,7 +49,7 @@ module Compass
       type :stylesheet, :plural => :stylesheets, :extensions => %w(scss sass)
       type :image,      :plural => :images,      :extensions => %w(png gif jpg jpeg tiff gif)
       type :javascript, :plural => :javascripts, :extensions => %w(js)
-      type :font,       :plural => :fonts,       :extensions => %w(otf woff ttf)
+      type :font,       :plural => :fonts,       :extensions => %w(eot otf woff ttf)
       type :html,       :plural => :html,        :extensions => %w(html haml)
       type :file,       :plural => :files
       type :directory,  :plural => :directories


### PR DESCRIPTION
Tiny PR.

Fix part of #752

I did not add .svg since it's not a real font format & it can create issues.
