### PR TITLE
Correct Mime type for woff font files

### DIFF
--- a/lib/compass/sass_extensions/functions/inline_image.rb
+++ b/lib/compass/sass_extensions/functions/inline_image.rb
@@ -42,7 +42,7 @@ private
     when /\.ttf$/i
       'font/truetype'
     when /\.woff$/i
-      'font/woff'
+      'application/x-font-woff'
     when /\.off$/i
       'font/openfont'
     when /\.([a-zA-Z]+)$/


### PR DESCRIPTION
http://stackoverflow.com/questions/3594823/mime-type-for-woff-fonts

This fixes a warning in chrome when using embedded fonts
