### PR TITLE
Fix for Compass.shared_extension_paths when HOME is a relative path.

### DIFF
--- a/lib/compass.rb
+++ b/lib/compass.rb
@@ -21,6 +21,8 @@ module Compass
       else
         []
       end
+    rescue ArgumentError # If HOME is relative
+      []
     end
   end
   module_function :base_directory, :lib_directory, :shared_extension_paths

--- a/test/units/compass_module_test.rb
+++ b/test/units/compass_module_test.rb
@@ -1,0 +1,36 @@
+require File.join(File.dirname(__FILE__), "..", "test_helper")
+
+class CompassModuleTest < Test::Unit::TestCase
+
+  def setup
+    Compass.reset_configuration!
+    Compass.instance_variable_set("@shared_extension_paths", nil)
+    @original_home = ENV["HOME"]
+  end
+
+  def teardown
+    ENV["HOME"] = @original_home
+    Compass.reset_configuration!
+  end
+
+  def test_shared_extension_paths_with_valid_home
+    ENV["HOME"] = "/"
+    assert_equal ["/.compass/extensions"], Compass.shared_extension_paths
+  end
+
+  def test_shared_extension_paths_with_nil_home
+    ENV["HOME"] = nil
+    assert_equal [], Compass.shared_extension_paths
+  end
+
+  def test_shared_extension_paths_with_file_home
+    ENV["HOME"] = __FILE__
+    assert_equal [], Compass.shared_extension_paths
+  end
+
+  def test_shared_extension_paths_with_relative_home
+    ENV["HOME"] = "."
+    assert_equal [], Compass.shared_extension_paths
+  end
+
+end


### PR DESCRIPTION
This should fully resolve https://github.com/chriseppstein/compass/issues/364 for when HOME is not just nil but also "." (or any other relative path). Added a complete set of unit tests around the method as well.

Addressed Win32 concerns in https://github.com/chriseppstein/compass/pull/761
