### PR TITLE
Add Thin and Foreman for doc-src

### DIFF
--- a/doc-src/Gemfile
+++ b/doc-src/Gemfile
@@ -1,5 +1,6 @@
 source :gemcutter
 
+gem 'foreman'
 gem 'nanoc3'
 gem 'thin'
 gem 'rdiscount'

--- a/doc-src/Gemfile
+++ b/doc-src/Gemfile
@@ -1,6 +1,7 @@
 source :gemcutter
 
 gem 'nanoc3'
+gem 'thin'
 gem 'rdiscount'
 gem 'thor'
 gem 'rack'

--- a/doc-src/Gemfile.lock
+++ b/doc-src/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       compass (>= 0.10.0.rc3)
     css_parser (1.0.1)
     fssm (0.2.7)
+    daemons (1.1.8)
+    eventmachine (0.12.10)
     haml (3.1.0)
     i18n (0.4.2)
     json (1.5.1)
@@ -38,6 +40,10 @@ GEM
       i18n (~> 0.4.1)
       rack (~> 1.2.1)
       tzinfo (~> 0.3.23)
+    thin (1.3.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.14.6)
     tzinfo (0.3.26)
 
@@ -63,4 +69,5 @@ DEPENDENCIES
   ruby-prof
   sass (>= 3.1)
   serve (= 1.0.0)
+  thin
   thor

--- a/doc-src/Gemfile.lock
+++ b/doc-src/Gemfile.lock
@@ -22,6 +22,9 @@ GEM
     fssm (0.2.7)
     daemons (1.1.8)
     eventmachine (0.12.10)
+    foreman (0.39.0)
+      term-ansicolor (~> 1.0.7)
+      thor (>= 0.13.6)
     haml (3.1.0)
     i18n (0.4.2)
     json (1.5.1)
@@ -40,6 +43,7 @@ GEM
       i18n (~> 0.4.1)
       rack (~> 1.2.1)
       tzinfo (~> 0.3.23)
+    term-ansicolor (1.0.7)
     thin (1.3.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -57,6 +61,7 @@ DEPENDENCIES
   compass-susy-plugin (>= 0.7.0.pre8)
   css-slideshow (= 0.2.0)
   css_parser (= 1.0.1)
+  foreman
   haml (>= 3.1)
   json
   mime-types

--- a/doc-src/Procfile
+++ b/doc-src/Procfile
@@ -1,0 +1,2 @@
+serve: ./bin/serve 3000 output
+rake:  ./bin/rake watch

--- a/doc-src/README.markdown
+++ b/doc-src/README.markdown
@@ -159,11 +159,11 @@ Bundle the gems for this application:
 To compile (and auto recompile) and preview the site in your browser,
 make sure you're in the `doc-src` directory, then run:
 
-    $ foreman start
+    $ ./bin/foreman start
 
 Then open `http://localhost:3000/index.html` in your web browser.
 
-The command `foreman start` runs two processes:
+This command runs two processes:
 
     $ ./bin/serve 3000 output
     $ ./bin/rake watch

--- a/doc-src/README.markdown
+++ b/doc-src/README.markdown
@@ -101,7 +101,7 @@ So you want to help documenting Compass?
 
 Setting up the documentation for Compass is not super-easy, but it's pretty doable.
 
-The Compass docs live in the source code of Compass. Not directly in the Sass files though: the documentation is a combination of inline comments and source code read directly from the Sass files, and hand-maintained documentation and examples. We use [Nanoc](http://nanoc.stoneship.org/) to generate a static website, combined with some Ruby to read the Compass source.
+The Compass docs live in the source code of Compass. Not directly in the Sass files though: the documentation is a combination of inline comments and source code read directly from the Sass files, and hand-maintained documentation and examples. There are two ways you can generate a static webiste, using [Serve](http://get-serve.com/) (with [Thin](http://code.macournoyer.com/thin/), to make it faster) or using [Nanoc](http://nanoc.stoneship.org/), both combined with some Ruby to read the Compass source.
 
 The reasons for this setup are simple:
 
@@ -156,20 +156,25 @@ Bundle the gems for this application:
 
 ### 4. Compile the docs
 
-To compile (and auto recompile) and preview the site in your browser: (make sure you run nanoc3 aco from the doc-src directory)
+To compile (and auto recompile) and preview the site in your browser,
+make sure you're in the `doc-src` directory, then run:
 
-    $ cd doc-src
-    $ ./bin/nanoc3 aco
+    $ foreman start
 
 Then open `http://localhost:3000/index.html` in your web browser.
 
-aco stands for autocompiler; the site will recompile every time you request a new page.
+The command `foreman start` runs two processes:
 
-If you find `./bin/nanoc3 aco` to be sluggish, try this alternative workflow:
-
-    $ cd doc-src
-    $ ./bin/serve 3000 output &
+    $ ./bin/serve 3000 output
     $ ./bin/rake watch
+
+If you're interested, you can read more about [Foreman](https://github.com/ddollar/foreman).
+
+Alternatively, you can try this:
+
+    $ ./bin/nanoc3 aco
+
+`aco` stands for *autocompiler* -- the site will recompile every time you request a new page.
 
 It is recommended that you read the 5 minute [tutorial](http://nanoc.stoneship.org/tutorial/) on Nanoc.
 

--- a/doc-src/README.markdown
+++ b/doc-src/README.markdown
@@ -101,7 +101,7 @@ So you want to help documenting Compass?
 
 Setting up the documentation for Compass is not super-easy, but it's pretty doable.
 
-The Compass docs live in the source code of Compass. Not directly in the Sass files though: the documentation is a combination of inline comments and source code read directly from the Sass files, and hand-maintained documentation and examples. There are two ways you can generate a static webiste, using [Serve](http://get-serve.com/) (with [Thin](http://code.macournoyer.com/thin/), to make it faster) or using [Nanoc](http://nanoc.stoneship.org/), both combined with some Ruby to read the Compass source.
+The Compass docs live in the source code of Compass. Not directly in the Sass files though: the documentation is a combination of inline comments and source code read directly from the Sass files, and hand-maintained documentation and examples. There are two ways you can generate a static webiste, using [Serve](http://get-serve.com/) and Nanoc (with Thin) or using only [Nanoc](http://nanoc.stoneship.org/), both combined with some Ruby to read the Compass source.
 
 The reasons for this setup are simple:
 


### PR DESCRIPTION
I (think I) made the Serve method faster with Thin. The Serve method is now primary, because the Nanoc method is really slow. I grouped those two Serve processes into a Procfile using Foreman, because the command `./bin/foreman start` is easier to remember and because I find it difficult to stop background processes, in this case `./bin/serve 300 output &`. (The Foreman version doesn't have the ampersand.)
