### PR TITLE
Optimized property-heavy mixins by having them extend a class

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/general/_clearfix.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/general/_clearfix.scss
@@ -10,6 +10,9 @@
 // Recommendations include using this in conjunction with a width.
 // Credit: [quirksmode.org](http://www.quirksmode.org/blog/archives/2005/03/clearing_floats.html)
 @mixin clearfix {
+  @extend .__compass-clearfix;
+}
+.__compass-clearfix {
   overflow: hidden;
   @include has-layout;
 }
@@ -19,6 +22,9 @@
 // has the advantage of allowing positioned elements to hang
 // outside the bounds of the container at the expense of more tricky CSS.
 @mixin legacy-pie-clearfix {
+  @extend .__compass-legacy-pie-clearfix;
+}
+.__compass-legacy-pie-clearfix {
   &:after {
     content    : "\0020";
     display    : block;
@@ -35,6 +41,9 @@
 //
 // Adapted from: [A new micro clearfix hack](http://nicolasgallagher.com/micro-clearfix-hack/)
 @mixin pie-clearfix {
+  @extend .__compass-pie-clearfix;
+}
+.__compass-pie-clearfix {
   &:after {
     content: "";
     display: table;


### PR DESCRIPTION
This is a method that I'm currently using in Stitch to reduce the total weight of the stylesheets. Basically, creating classes for properties that are using in frequently used mixins, like clearfix can reduce the bloat of a stylesheet a great deal. 

You get the same interface of including a mixin so it doesn't require the user to create the class themselves. However, the mixin itself could be extended to allow the user to choose the class that is extended. (If it's even possible in Sass).

An added benefit to this is debugging. When inspecting the element the properties used for clearfixing are all grouped together. This means you won't see an overflow hidden in your property list for that selected element and not know what it's there for.

I'd like to see what other people think of this approach. As I said, I've been using this with Stitch for a while now with a number of mixins with no real drawbacks. So it could easily be extended to the other work-horse mixins of the framework. 

Although one drawback maybe that as soon as you import compass into the stylesheet you'll be adding these classes to the users stylesheet. Not a big deal really (for me), but it might have people complaining about compass bloating their stylesheets (which is ironic as it will actually reduce the total weight of the file in the end).
