### PR TITLE
Fix code style in vertical_rhythm's apply-side-rhythm-border().

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -193,7 +193,8 @@ $base-half-leader: $base-leader / 2;
   }
   border: {
     style: $border-style;
-    width: $font-unit * $width / $font-size; };
+    width: $font-unit * $width / $font-size;
+  };
   padding: $font-unit / $font-size * ($lines * $base-line-height - $width);
 }
 


### PR DESCRIPTION
This is just a minor code style fix. There should be a newline before the closing } bracket.
