### PR TITLE
Simplify code in vertical_rhythm's adjust-leading-to() using rhythm() function

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -98,10 +98,7 @@ $base-half-leader: $base-leader / 2;
 // font should use up. It does not have to be an integer, but it defaults to the
 // smallest integer that is large enough to fit the font.
 @mixin adjust-leading-to($lines, $font-size: $base-font-size) {
-  @if not $relative-font-sizing and $font-size != $base-font-size {
-    @warn "$relative-font-sizing is false but a relative font size was passed to adjust-leading-to";
-  }
-  line-height: $font-unit * $lines * $base-line-height / $font-size;
+  line-height: rhythm($lines, $font-size);
 }
 
 // Calculate rhythm units.


### PR DESCRIPTION
The code in the `adjust-leading-to()` mixin is almost a complete duplicate of the code in the `rhythm()` function.

We should simplify the `adjust-leading-to()` mixin to remove the duplicate code and replace with a call to `rhythm()`.

Here's what the mixin and function currently look like:

```
@mixin adjust-leading-to($lines, $font-size: $base-font-size) {
  @if not $relative-font-sizing and $font-size != $base-font-size {
    @warn "$relative-font-sizing is false but a relative font size was passed to adjust-leading-to";
  }
  line-height: $font-unit * $lines * $base-line-height / $font-size;
}

@function rhythm(
  $lines: 1,
  $font-size: $base-font-size
) {
  @if not $relative-font-sizing and $font-size != $base-font-size {
    @warn "$relative-font-sizing is false but a relative font size was passed to the rhythm function";
  }
  $rhythm: $font-unit * $lines * $base-line-height / $font-size;
  @return $rhythm;
}
```

This commit changes `adjust-leading-to()` to be:

```
@mixin adjust-leading-to($lines, $font-size: $base-font-size) {
  line-height: rhythm($lines, $font-size);
}
```
