### PR TITLE
Remove (or explain) reset-baseline in vertical rhythym parital

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -64,11 +64,6 @@ $base-half-leader: $base-leader / 2;
   }
 }
 
-// resets the baseline to 1 leading unit
-@mixin reset-baseline {
-  @include adjust-leading-to(1, if($relative-font-sizing, $base-font-size, $base-font-size));
-}
-
 // Show a background image that can be used to debug your alignments.
 // Include the $img argument if you would rather use your own image than the
 // Compass default gradient image.

--- a/test/fixtures/stylesheets/compass/css/vertical_rhythm.css
+++ b/test/fixtures/stylesheets/compass/css/vertical_rhythm.css
@@ -40,6 +40,3 @@ html > body {
   border-bottom-style: solid;
   border-bottom-width: 0.25em;
   padding-bottom: 0.417em; }
-
-.reset {
-  line-height: 1.143em; }

--- a/test/fixtures/stylesheets/compass/sass/vertical_rhythm.scss
+++ b/test/fixtures/stylesheets/compass/sass/vertical_rhythm.scss
@@ -12,5 +12,3 @@ $base-line-height: 16px;
 
 .borders { @include h-borders(1px,1); }
 .large-borders { @include adjust-font-size-to(24px,3); @include h-borders(6px,1,24px); }
-
-.reset { @include reset-baseline; }


### PR DESCRIPTION
The attached commit reverts commit c92766ba99d7f2c6f00f666c804cbc8e6de309f2.

I looked at the new `reset-baseline()` mixin in Compass 0.12 and I'm completely at a loss for why it was added. @scottdavis, can you share your thoughts?

Firstly, the `if($relative-font-sizing, $base-font-size, $base-font-size)` has to be a typo, right?

Also, the name seems misleading. reset-baseline should set the font size and the line height, I would think. `establish-baseline()` sets the font size and the line height. But `reset-baseline()` only sets the line height.

Finally, since `$relative-font-sizing` defaults to true and `$font-unit` defaults to 1em, the `reset-baseline()` mixin sets a line height that is relative to… the element's font size. And if the element's font size isn't the base font size, then the line-height has been set to a value which is NOT conforming to the base line height/vertical rhythm.

It appears you can only use this mixin if the element happens to be using a font size equal to $base-font-size.
