### PR TITLE
Support css3 input placeholder

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
@@ -5,9 +5,9 @@
 // 1. Webkit and Gecko (Mozilla) already support placeholders (2012/Mar/13)
 // 2. Future-proofing for IE10: http://msdn.microsoft.com/library/ie/hh772745.aspx
 @mixin input-placeholder {
-	&::-webkit-input-placeholder { @content; }	// [1]
-	&:-moz-placeholder { @content; }						// [1]
-	&:-ms-input-placeholder { @content; }				// [2]
+	&::-webkit-input-placeholder { @content; }  // [1]
+	&:-moz-placeholder { @content; }            // [1]
+	&:-ms-input-placeholder { @content; }       // [2]
 }
 
 // Shortcut to set the color of html5 input placeholder text.

--- a/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
@@ -5,9 +5,15 @@
 // 1. Webkit and Gecko (Mozilla) already support placeholders (2012/Mar/13)
 // 2. Future-proofing for IE10: http://msdn.microsoft.com/library/ie/hh772745.aspx
 @mixin input-placeholder {
-	&::-webkit-input-placeholder { @content; }  // [1]
-	&:-moz-placeholder { @content; }            // [1]
-	&:-ms-input-placeholder { @content; }       // [2]
+	@if $experimental-support-for-webkit {
+		&::-webkit-input-placeholder { @content; }  // [1]
+	}
+	@if $experimental-support-for-mozilla {
+		&:-moz-placeholder { @content; }            // [1]
+	}
+	@if $experimental-support-for-microsoft {
+		&:-ms-input-placeholder { @content; }       // [2]
+	}
 }
 
 // Shortcut to set the color of html5 input placeholder text.

--- a/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
@@ -1,0 +1,18 @@
+// Style the html5 input placeholder in browsers that support it.
+// Requires that style rules be provided to the mixin using the @content feature.
+// For more on @content, see https://gist.github.com/1884016
+// 
+// 1. Webkit and Gecko (Mozilla) already support placeholders (2012/Mar/13)
+// 2. Future-proofing for IE10: http://msdn.microsoft.com/library/ie/hh772745.aspx
+@mixin input-placeholder {
+	&::-webkit-input-placeholder { @content; }	// [1]
+	&:-moz-placeholder { @content; }						// [1]
+	&:-ms-input-placeholder { @content; }				// [2]
+}
+
+// Shortcut to set the color of html5 input placeholder text.
+@mixin input-placeholder-color($color) {
+	@include input-placeholder {
+		color: $color;
+	}
+}

--- a/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_input-placeholder.scss
@@ -15,10 +15,3 @@
 		&:-ms-input-placeholder { @content; }       // [2]
 	}
 }
-
-// Shortcut to set the color of html5 input placeholder text.
-@mixin input-placeholder-color($color) {
-	@include input-placeholder {
-		color: $color;
-	}
-}


### PR DESCRIPTION
Add +input-placeholder to style the html5 input pseudo-element in Mozilla, Webkit and IE10. Uses the @content feature of Sass.

Add mixin +input-placeholder-color($color) as shortcut to change the colour of the input placeholder.

Proposal to close #418.
