### PR TITLE
Deprecate reset-baseline mixin from vertical-rhythm partial

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -67,8 +67,9 @@ $base-half-leader: $base-leader / 2;
   }
 }
 
-// resets the baseline to 1 leading unit
+// @deprecated Resets the baseline to 1 leading unit.
 @mixin reset-baseline {
+  @warn "This mixin has been deprecated and will be removed in the next version. Use adjust-leading-to(1) instead.";
   @include adjust-leading-to(1, if($relative-font-sizing, $base-font-size, $base-font-size));
 }
 

--- a/test/fixtures/stylesheets/compass/css/vertical_rhythm.css
+++ b/test/fixtures/stylesheets/compass/css/vertical_rhythm.css
@@ -40,6 +40,3 @@ html {
   border-bottom-style: solid;
   border-bottom-width: 0.25em;
   padding-bottom: 0.417em; }
-
-.reset {
-  line-height: 1.143em; }

--- a/test/fixtures/stylesheets/compass/sass/vertical_rhythm.scss
+++ b/test/fixtures/stylesheets/compass/sass/vertical_rhythm.scss
@@ -12,5 +12,3 @@ $base-line-height: 16px;
 
 .borders { @include h-borders(1px,1); }
 .large-borders { @include adjust-font-size-to(24px,3); @include h-borders(6px,1,24px); }
-
-.reset { @include reset-baseline; }


### PR DESCRIPTION
Follow-up to #780 to deprecate reset-baseline() mixin.
