### PR TITLE
Update docs for reset-baseline() in vertical_rhythm partial

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -64,7 +64,8 @@ $base-half-leader: $base-leader / 2;
   }
 }
 
-// resets the baseline to 1 leading unit
+// Resets the line-height to 1 vertical rhythm unit. Does not work in all
+// circumstances.
 @mixin reset-baseline {
   @include adjust-leading-to(1, if($relative-font-sizing, $base-font-size, $base-font-size));
 }


### PR DESCRIPTION
Over in #780 the decision was made to deprecate the reset-baseline() partial in the master branch that will be Compass 0.13 (which I did in #790).

But we still need to better document that mixin in the stable 0.12 branch.

Here's a better description of the mixin with a mild warning about it not working in all circumstances.
