### PR TITLE
Remove unused -o-border-radius and -ms-border-radius

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_border-radius.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_border-radius.scss
@@ -21,24 +21,18 @@ $default-border-radius: 5px !default;
 //    .simple {
 //      -webkit-border-radius: 4px 4px;
 //      -moz-border-radius: 4px / 4px;
-//      -o-border-radius: 4px / 4px;
-//      -ms-border-radius: 4px / 4px;
 //      -khtml-border-radius: 4px / 4px;
 //      border-radius: 4px / 4px; }
 //    
 //    .compound {
 //      -webkit-border-radius: 2px 3px;
 //      -moz-border-radius: 2px 5px / 3px 6px;
-//      -o-border-radius: 2px 5px / 3px 6px;
-//      -ms-border-radius: 2px 5px / 3px 6px;
 //      -khtml-border-radius: 2px 5px / 3px 6px;
 //      border-radius: 2px 5px / 3px 6px; }
 //    
 //    .crazy {
 //      -webkit-border-radius: 1px 2px;
 //      -moz-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
-//      -o-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
-//      -ms-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
 //      -khtml-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
 //      border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px; }
 
@@ -58,8 +52,8 @@ $default-border-radius: 5px !default;
     @include experimental("border-radius", $radius unquote("/") $vertical-radius,
       -moz,
       not -webkit,
-      -o,
-      -ms,
+      not -o,
+      not -ms,
       -khtml,
       official
     );
@@ -87,8 +81,8 @@ $default-border-radius: 5px !default;
   @include experimental("border-#{$vert}-#{$horz}-radius", $radius,
     not -moz,
     -webkit,
-    -o,
-    -ms,
+    not -o,
+    not -ms,
     -khtml,
     official
   );

--- a/test/fixtures/stylesheets/compass/css/border_radius.css
+++ b/test/fixtures/stylesheets/compass/css/border_radius.css
@@ -1,20 +1,14 @@
 .simple {
   -webkit-border-radius: 4px 4px;
   -moz-border-radius: 4px / 4px;
-  -ms-border-radius: 4px / 4px;
-  -o-border-radius: 4px / 4px;
   border-radius: 4px / 4px; }
 
 .compound {
   -webkit-border-radius: 2px 3px;
   -moz-border-radius: 2px 5px / 3px 6px;
-  -ms-border-radius: 2px 5px / 3px 6px;
-  -o-border-radius: 2px 5px / 3px 6px;
   border-radius: 2px 5px / 3px 6px; }
 
 .crazy {
   -webkit-border-radius: 1px 2px;
   -moz-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
-  -ms-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
-  -o-border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px;
   border-radius: 1px 3px 5px 7px / 2px 4px 6px 8px; }


### PR DESCRIPTION
Neither Opera nor Microsoft ever implemented vendor prefixes for the border-radius property. So they can just be removed.
