### PR TITLE
Remove stray commas when default transition properties are used

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_transition.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transition.scss
@@ -95,7 +95,7 @@ $transitionable-prefixed-values: transform, transform-origin !default;
   $transition-10: false
 ) {
   @if $transition-1 == default {
-    $transition-1 : (compact($default-transition-property, $default-transition-duration, $default-transition-function, $default-transition-delay));
+    $transition-1 : compact($default-transition-property $default-transition-duration $default-transition-function $default-transition-delay);
   }
 
   $transition : compact($transition-1, $transition-2, $transition-3, $transition-4, $transition-5, $transition-6, $transition-7, $transition-8, $transition-9, $transition-10);

--- a/test/fixtures/stylesheets/compass/css/transition.css
+++ b/test/fixtures/stylesheets/compass/css/transition.css
@@ -69,3 +69,10 @@
   -ms-transition-property: opacity, -ms-transform, left;
   -o-transition-property: opacity, -o-transform, left;
   transition-property: opacity, transform, left; }
+
+.default-transition {
+  -webkit-transition: all 1s;
+  -moz-transition: all 1s;
+  -ms-transition: all 1s;
+  -o-transition: all 1s;
+  transition: all 1s; }

--- a/test/fixtures/stylesheets/compass/sass/transition.scss
+++ b/test/fixtures/stylesheets/compass/sass/transition.scss
@@ -10,3 +10,4 @@
 .multiple-transitions { @include transition(transform 0.6s ease-out, opacity 0.2s ease-in) }
 .transition-property { @include transition-property(transform); }
 .multiple-transition-properties { @include transition-property((opacity, transform, left)); }
+.default-transition { @include transition(); }


### PR DESCRIPTION
Resolves issue #805. Test case included.
