### PR TITLE
Fixed the sprite Magic Selectors

### DIFF
--- a/lib/compass/sass_extensions/functions/sprites.rb
+++ b/lib/compass/sass_extensions/functions/sprites.rb
@@ -110,7 +110,7 @@ module Compass::SassExtensions::Functions::Sprites
     unless VALID_SELECTORS.include?(selector.value)
       raise Sass::SyntaxError, "Invalid Selctor did you mean one of: #{VALID_SELECTORS.join(', ')}"
     end
-    Sass::Script::Bool.new map.send(:"has_#{selector.value}?", sprite)
+    Sass::Script::Bool.new map.send(:"has_#{selector.value}?", sprite.value)
   end
   
   Sass::Script::Functions.declare :sprite_has_selector, [:map, :sprite, :selector]


### PR DESCRIPTION
The sprite magic selectors fail to detect the files with selector variants like `my-file_hover` because an instance of `Sass::Script::String` is passed to the corresponding helper (i.e. `Compass::SassExtensions::Sprites::ImageMethods#has_hover?`) instead of a `String`.
Therefore, this helper asks to `Compass::SassExtensions::Sprites::ImageMethods#image_for` if `"my-file"_hover` exists — _note the double quotes_ —  (which is not the case, of course).
