### PR TITLE
Fix for text-replacement IE7 bug

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -28,7 +28,7 @@
 @mixin hide-text {
   // slightly wider than the box prevents issues with inline-block elements
   // minus because of wrong behaviour in IE7
-  text-indent: -110%;
+  text-indent: -9999px;
   white-space: nowrap;
   overflow: hidden;
 }

--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -27,7 +27,8 @@
 // Hides text in an element so you can see the background.
 @mixin hide-text {
   // slightly wider than the box prevents issues with inline-block elements
-  text-indent: 110%;
+  // minus because of wrong behaviour in IE7
+  text-indent: -110%;
   white-space: nowrap;
   overflow: hidden;
 }


### PR DESCRIPTION
Hi team Compass,

I've noticed a problem with the text-replacement mixin in IE7. The background seemed to disappear with the positive text-indent. When negative, everything is fine.

Tested in:

Mac: Firefox 11, Chrome 18.0.1025.142, Safari 5.1.5, Opera 11.61
iOS 5
PC: IE9, (IE8 & IE7 simulated in IE9)

Cheers
