### PR TITLE
Add $offset parameter to rhythm() function.

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -111,12 +111,13 @@ $base-half-leader: $base-leader / 2;
 // Calculate rhythm units.
 @function rhythm(
   $lines: 1,
-  $font-size: $base-font-size
+  $font-size: $base-font-size,
+  $offset: 0
 ) {
   @if not $relative-font-sizing and $font-size != $base-font-size {
     @warn "$relative-font-sizing is false but a relative font size was passed to the rhythm function";
   }
-  $rhythm: $font-unit * $lines * $base-line-height / $font-size;
+  $rhythm: $font-unit * ($lines * $base-line-height - $offset) / $font-size;
   // Round the pixels down to nearest integer.
   @if unit($rhythm) == px {
     $rhythm: floor($rhythm);
@@ -183,7 +184,7 @@ $base-half-leader: $base-leader / 2;
     style: $border-style;
     width: $font-unit * $width / $font-size;
   };
-  padding-#{$side}: $font-unit / $font-size * ($lines * $base-line-height - $width);
+  padding-#{$side}: rhythm($lines, $font-size, $offset: $width);
 }
 
 // Apply borders and whitespace equally to all sides.
@@ -195,7 +196,7 @@ $base-half-leader: $base-leader / 2;
     style: $border-style;
     width: $font-unit * $width / $font-size;
   };
-  padding: $font-unit / $font-size * ($lines * $base-line-height - $width);
+  padding: rhythm($lines, $font-size, $offset: $width);
 }
 
 // Apply a leading border.


### PR DESCRIPTION
I was writing a mixin that needed to subtract a couple pixels from the vertical rhythm margin, just like the rhythm borders mixins do.

And then I noticed the math the rhythm border mixins are using is _almost_ identical to the math in the `rhythm()` function.

Keeping with DRY, I'd like to propose we add an $offset parameter to the `rhythm()` function.

Then I can use `rhythm()` in my mixin instead of copy/pasting/rewriting lines of code from the rhythm borders mixins.

Note that the $offset parameter is totally backwards compatible with existing usage of the `rhythm()` function. No one's existing Sass should be affected.
