### PR TITLE
[#852] Fix ordering of font properties in reset-font for FF's benefit.

### DIFF
--- a/frameworks/compass/stylesheets/compass/reset/_utilities.scss
+++ b/frameworks/compass/stylesheets/compass/reset/_utilities.scss
@@ -67,8 +67,8 @@
 
 // Reset the font and vertical alignment.
 @mixin reset-font {
-  font-size: 100%;
   font: inherit;
+  font-size: 100%;
   vertical-align: baseline; }
 
 // Resets the outline when focus.

--- a/test/fixtures/stylesheets/blueprint/css/screen.css
+++ b/test/fixtures/stylesheets/blueprint/css/screen.css
@@ -14,8 +14,8 @@ time, mark, audio, video {
   margin: 0;
   padding: 0;
   border: 0;
-  font-size: 100%;
   font: inherit;
+  font-size: 100%;
   vertical-align: baseline; }
 
 body {


### PR DESCRIPTION
Firefox gets persnickety about how regular CSS properties and shorthand properties
interact, specifically specifying a shorthand version after the regular property
causes the regular property to be overriden. Closes GH-852.
