### PR TITLE
Multiple image dirs

### DIFF
--- a/doc-src/content/reference/compass/helpers/image-dimensions.haml
+++ b/doc-src/content/reference/compass/helpers/image-dimensions.haml
@@ -20,8 +20,8 @@ documented_functions:
       image-width(<span class="arg">$image</span>)
   .details
     %p
-      Returns the width of the image found at the path supplied by <code>$image</code>
-      relative to your project's images directory.
+      Returns the width of the first image found at the path supplied by <code>$image</code>
+      relative to your project's image directories.
 
 #image-height.helper
   %h3
@@ -29,5 +29,5 @@ documented_functions:
       image-height(<span class="arg">$image</span>)
   .details
     %p
-      Returns the height of the image found at the path supplied by <code>$image</code>
-      relative to your project's images directory.
+      Returns the height of the first image found at the path supplied by <code>$image</code>
+      relative to your project's image directories.

--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -19,7 +19,6 @@ module Compass
       # Where are the various bits of the project
       attributes_for_directory(:css, :stylesheets),
       attributes_for_directory(:sass, nil),
-      attributes_for_directory(:images),
       attributes_for_directory(:generated_images),
       attributes_for_directory(:javascripts),
       attributes_for_directory(:fonts),
@@ -44,11 +43,12 @@ module Compass
     ].flatten
 
     ARRAY_ATTRIBUTES = [
+      attributes_for_directory(:images),
       :sprite_load_path,
       :required_libraries,
       :loaded_frameworks,
       :framework_path
-    ]
+    ].flatten
     # Registers a new configuration property.
     # Extensions can use this to add new configuration options to compass.
     #

--- a/lib/compass/configuration/data.rb
+++ b/lib/compass/configuration/data.rb
@@ -57,10 +57,10 @@ module Compass
       chained_method :run_stylesheet_error
 
       inherited_accessor *ATTRIBUTES
-
-      strip_trailing_separator *ATTRIBUTES.select{|a| a.to_s =~ /dir|path/}
-
       inherited_array *ARRAY_ATTRIBUTES
+
+      strip_trailing_separator *(ATTRIBUTES+ARRAY_ATTRIBUTES).select{|a| a.to_s =~ /dir|path/}
+
 
       def initialize(name, attr_hash = nil)
         raise "I need a name!" unless name

--- a/lib/compass/configuration/paths.rb
+++ b/lib/compass/configuration/paths.rb
@@ -5,15 +5,30 @@ module Compass::Configuration::Paths
   def strip_trailing_separator(*attributes)
     attributes.each do |attr|
       alias_method "#{attr}_with_trailing_separator".to_sym, attr
-      class_eval %Q{
-        def #{attr}                                # def css_dir
-          path = #{attr}_with_trailing_separator   #   path = css_dir_with_trailing_separator
-          if path.to_s =~ TRAILING_SEPARATOR       #   if path =~ TRAILING_SEPARATOR
-            path = path[0..-($1.length+1)]         #     path = path[0..-($1.length+1)]
-          end                                      #   end
-          path                                     #   path
-        end                                        # end
-      }
+      if Compass::Configuration::ARRAY_ATTRIBUTES.include? attr
+        class_eval %Q{
+          def #{attr}                                # def css_dir
+            paths = #{attr}_with_trailing_separator  #   paths = css_dir_with_trailing_separator
+            paths.map do |path|
+              if path.to_s =~ TRAILING_SEPARATOR       #   if path =~ TRAILING_SEPARATOR
+                path[0..-($1.length+1)]         #     path = path[0..-($1.length+1)]
+              else
+                path
+              end
+            end                                      #   end                                     #   path
+          end                                        # end
+        }
+      else
+        class_eval %Q{
+          def #{attr}                                # def css_dir
+            path = #{attr}_with_trailing_separator   #   path = css_dir_with_trailing_separator
+            if path.to_s =~ TRAILING_SEPARATOR       #   if path =~ TRAILING_SEPARATOR
+              path = path[0..-($1.length+1)]         #     path = path[0..-($1.length+1)]
+            end                                      #   end
+            path                                     #   path
+          end                                        # end
+        }
+      end
     end
   end
 end

--- a/lib/compass/configuration/paths.rb
+++ b/lib/compass/configuration/paths.rb
@@ -9,12 +9,12 @@ module Compass::Configuration::Paths
         class_eval %Q{
           def #{attr}                                # def css_dir
             paths = #{attr}_with_trailing_separator  #   paths = css_dir_with_trailing_separator
-            paths.map do |path|
-              if path.to_s =~ TRAILING_SEPARATOR       #   if path =~ TRAILING_SEPARATOR
-                path[0..-($1.length+1)]         #     path = path[0..-($1.length+1)]
-              else
-                path
-              end
+            paths.map do |path|                      #   paths.map do |path| 
+              if path.to_s =~ TRAILING_SEPARATOR     #     if path =~ TRAILING_SEPARATOR
+                path[0..-($1.length+1)]              #       path = path[0..-($1.length+1)]
+              else                                   #     else
+                path                                 #       path
+              end                                    #     end
             end                                      #   end                                     #   path
           end                                        # end
         }

--- a/test/units/actions_test.rb
+++ b/test/units/actions_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path("../../test_helper", __FILE__)
 require 'compass'
 
 class ActionsTest < Test::Unit::TestCase

--- a/test/units/command_line_test.rb
+++ b/test/units/command_line_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path("../../test_helper", __FILE__)
 require 'fileutils'
 require 'compass'
 require 'compass/exec'

--- a/test/units/compass_module_test.rb
+++ b/test/units/compass_module_test.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "..", "test_helper")
+require File.expand_path("../../test_helper", __FILE__)
 
 class CompassModuleTest < Test::Unit::TestCase
 

--- a/test/units/compass_png_test.rb
+++ b/test/units/compass_png_test.rb
@@ -1,4 +1,5 @@
-require 'test_helper'
+require File.expand_path("../../test_helper", __FILE__)
+require 'compass/grid_builder'
 require 'fileutils'
 
 class CompassPngTest < Test::Unit::TestCase

--- a/test/units/compiler_test.rb
+++ b/test/units/compiler_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path("../../test_helper", __FILE__)
 require 'fileutils'
 
 class CompilerTest < Test::Unit::TestCase

--- a/test/units/configuration_test.rb
+++ b/test/units/configuration_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path("../../test_helper", __FILE__)
 require 'compass'
 require 'stringio'
 
@@ -22,7 +22,6 @@ class ConfigurationTest < Test::Unit::TestCase
       http_path = "/"
       css_dir = "css"
       sass_dir = "sass"
-      images_dir = "img"
       javascripts_dir = "js"
       
       output_style = :nested
@@ -39,13 +38,14 @@ class ConfigurationTest < Test::Unit::TestCase
       # preferred_syntax = :sass
       # and then run:
       # sass-convert -R --from scss --to sass sass scss && rm -rf sass && mv scss sass
+      images_dir = ["img"]
     CONFIG
 
     Compass.add_configuration(contents, "test_parse")
 
     assert_equal 'sass', Compass.configuration.sass_dir
     assert_equal 'css', Compass.configuration.css_dir
-    assert_equal 'img', Compass.configuration.images_dir
+    assert_equal 'img', Compass.configuration.images_dir.first
     assert_equal 'js', Compass.configuration.javascripts_dir
 
     expected_lines = contents.string.split("\n").map{|l|l.strip}
@@ -374,7 +374,7 @@ EXPECTED
 
     assert_equal "css", Compass.configuration.css_dir
     assert_equal "sass", Compass.configuration.sass_dir
-    assert_equal "images", Compass.configuration.images_dir
+    assert_equal "images", Compass.configuration.images_dir.first
     assert_equal "js", Compass.configuration.javascripts_dir
     assert_equal "fonts", Compass.configuration.fonts_dir
     assert_equal "extensions", Compass.configuration.extensions_dir

--- a/test/units/sass_extensions_test.rb
+++ b/test/units/sass_extensions_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require File.expand_path("../../test_helper", __FILE__)
 
 class SassExtensionsTest < Test::Unit::TestCase
   def test_simple


### PR DESCRIPTION
Support for multiple image dirs.

When working with Rails > 3.1, images are located at different locations. (app/assets, vendor/assets, lib/assets, you name it). So it would be nice if compass supports multiple image dirs when using the image dimension helpers.

This branch goes hand-in-hand with the the multiple_image_dirs branch for compass-rails: https://github.com/buhrmi/compass-rails/commit/fee5b8ab525951438196edf516fc601fd0f6861f
