### PR TITLE
add a sprite-image-position() helper function

### DIFF
--- a/lib/compass/sass_extensions/functions/sprites.rb
+++ b/lib/compass/sass_extensions/functions/sprites.rb
@@ -174,6 +174,23 @@ module Compass::SassExtensions::Functions::Sprites
     raise Sass::SyntaxError, %Q(The sprite-image() function has been replaced by sprite(). See http://compass-style.org/help/tutorials/spriting/ for more information.)
   end
 
+  # Returns the position of the sprite in the sprite map specified by $<map>-<sprite>-position
+  # This can be useful for automatically adjusting the background-position property 
+  def sprite_image_position(map, sprite)
+    verify_map(map, "sprite-image-position")
+    sprite = convert_sprite_name(sprite)
+    unless sprite && sprite.is_a?(Sass::Script::String)
+      raise Sass::SyntaxError, %Q(The second argument to sprite-image-position must be a sprite name.)
+    end
+    image = map.image_for(sprite.value)
+    unless image
+      missing_image!(map, sprite)
+    end
+    image.position
+  end
+  Sass::Script::Functions.declare :sprite_image_position, [:map, :sprite]
+end
+
 protected
 
   def convert_sprite_name(sprite)

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -840,4 +840,27 @@ class SpritesTest < Test::Unit::TestCase
 
   end
 
+  it "should use the image position of the sprite in the sprite map" do
+    css = render <<-SCSS
+      $squares-position: 100%;
+      @import "squares/*.png";
+      .adjusted-ten {
+        @include squares-sprite("ten-by-ten", $offset-x: sprite-image-position($square-sprites, "ten-by-ten"));
+      }
+      .adjusted-twenty {
+        @include squares-sprite("twenty-by-twenty", $offset-x: sprite-image-position($square-sprites, "twenty-by-twenty"));
+      }
+    SCSS
+    other_css = <<-CSS
+      .adjusted-ten {
+        background-position: 100% 0;
+      }
+      .adjusted-twenty {
+        background-position: 100% -20px;
+      }
+
+    CSS
+    assert_correct clean(css), clean(other_css)
+  end
+
 end


### PR DESCRIPTION
This is would be really useful for for automatic sprite handling. I use Compass spriting in many group projects and often other people don't want to deal with advanced spriting.

I don't insert elements just for icons so for an icon that's supposed to be on the very right side of a block element, I would normally do something like:

```
$map-sprite-position: 100%;
...
.map-sprite {
  @include sprite-background-position($map-sprites, sprite, 100%);
}
```

Using this helper method, I can then write something like:

```
@mixin adjust-sprite-positions($map) {
  @each $sprite in sprite-names($map) {
    $position: sprite-image-position($map, $sprite);
    @if $position != 0 and unit($position) == "%" {
      .#{sprite-map-name($map)-$sprite} {
        @include sprite-background-position($map, $sprite, $position);
      }
    }
  }
}
```
