### PR TITLE
Fix documentation issue #836

### DIFF
--- a/doc-src/content/help/tutorials/spriting.markdown
+++ b/doc-src/content/help/tutorials/spriting.markdown
@@ -69,7 +69,7 @@ Sprites stored in a nested folder will use the last folder name in the path as t
 Example:
 
       @import "themes/orange/*.png";
-      @include all-orange-sprite;
+      @include all-orange-sprites;
     
 <a name="selector-control" id="selector-control"></a>
 ## Selector Control


### PR DESCRIPTION
I believe issue #836 is valid. In some of my SCSS code, I actually use this syntax:

```
$notification-spacing: 75px;
@import "notification/*.png";
@include all-notification-sprites;
```

I also verified, if I remove the s, get the following error:

```
    error sass/notification.scss (Line 3: Undefined mixin 'all-notification-sprite'.)
```
