### PR TITLE
Fix finding bundler

### DIFF
--- a/bin/compass
+++ b/bin/compass
@@ -22,7 +22,8 @@ fallback_load_path(File.join(File.dirname(__FILE__), '..', 'lib')) do
 end
 
 if defined?(Bundler)
-  Bundler.require :assets
+  require 'bundler/shared_helpers'
+  Bundler.require :assets if Bundler::SharedHelpers.in_bundle?
 end
 
 runner = Proc.new do


### PR DESCRIPTION
it's related to this SO answer: http://stackoverflow.com/questions/10610254/cant-install-compass-via-rvm/10611366#10611366

I was talking to @wycats and there are two possible solutions:

1) detect if Gemfile is in effect - this pull request:

```
if defined?(Bundler)
  require 'bundler/shared_helpers'
  Bundler.require :assets if Bundler::SharedHelpers.in_bundle?
end
```

2) detect if `Bundlr.setup` was called:

```
if defined?(Bundler) && Bundler.instance_variable_defined?("@setup")
  Bundler.require :assets
end
```
