### PR TITLE
It doesn't need two selectors for this hack. Less selectors, less bits. ...

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_inline-block.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_inline-block.scss
@@ -3,14 +3,13 @@
 // Provides a cross-browser method to implement `display: inline-block;`
 
 @mixin inline-block {
-  @if $legacy-support-for-ie {
-    & { *display: inline; }
-  }
-  display: -moz-inline-box;
+  display: -moz-inline-stack;
   -moz-box-orient: vertical;
   display: inline-block;
   vertical-align: middle;
   @if $legacy-support-for-ie {
     *vertical-align: auto;
+    zoom: 1;
+    *display: inline;
   }
 }


### PR DESCRIPTION
...Plus it needs hasLayout (with zoom: 1) to work perfectly. And it's "stack" and not "box" for Firefox 1 and 2.
