### PR TITLE
Fix gradient-type arg

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_images.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_images.scss
@@ -82,7 +82,7 @@
 // any background-image properties that you have specified.
 @mixin filter-gradient($start-color, $end-color, $orientation: vertical) {
   @include has-layout;
-  $gradient-type: if($orientation == vertical, 0, 1);
+  $gradient-type: if($orientation == vertical, 1);
   @if $legacy-support-for-ie6 or $legacy-support-for-ie7 or $legacy-support-for-ie8 {
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=#{$gradient-type}, startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}');
   }


### PR DESCRIPTION
When

```
@include filter-gradient(rgba(255,255,255,0.2), rgba(255,255,255,0.7), 0);
```

it generates

`filter: progid:DXImageTransform.Microsoft.gradient(gradientType=1, startColorstr='#33FFFFFF', endColorstr='#B3FFFFFF');`

 which should be

`filter: progid:DXImageTransform.Microsoft.gradient(gradientType=0, startColorstr='#33FFFFFF', endColorstr='#B3FFFFFF');`
