### PR TITLE
Retrieve image properties from filesystem-like objects

### DIFF
--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -40,7 +40,8 @@ module Compass
       :preferred_syntax,
       :disable_warnings,
       :sprite_engine,
-      :chunky_png_options
+      :chunky_png_options,
+      :images_file_source
     ].flatten
 
     ARRAY_ATTRIBUTES = [

--- a/test/units/sass_extensions_test.rb
+++ b/test/units/sass_extensions_test.rb
@@ -166,16 +166,29 @@ class SassExtensionsTest < Test::Unit::TestCase
     base64_string = File.read(File.join(Compass.configuration.fonts_path, "bgrove.base64.txt")).chomp
     assert_equal "url('data:font/truetype;base64,#{base64_string}') format('truetype')", evaluate("inline_font_files('bgrove.ttf', truetype)")
   end
-  
-  
+
   def test_image_size_should_respond_to_to_path
     object = mock()
     object.expects(:to_path).returns('foo.jpg')
     object.expects(:respond_to?).with(:to_path).returns(true)
-    
+
     Compass::SassExtensions::Functions::ImageSize::ImageProperties.new(object)
   end
-  
+
+  def test_image_properites_should_be_able_to_use_file_like_object
+    source = Class.new do
+      def self.open(*args, &block)
+        File.open(*args, &block)
+      end
+    end
+
+    Compass.configuration.images_file_source = lambda { |file| source.open(file) }
+
+    properties = Compass::SassExtensions::Functions::ImageSize::ImageProperties.new('test/fixtures/sprites/public/images/colors/blue.png')
+
+    assert_equal [ 10, 10 ], properties.size
+  end
+
   def test_reject
     assert_equal "b d", evaluate("reject(a b c d, a, c)")
     assert_equal "a b c d", evaluate("reject(a b c d, e)")


### PR DESCRIPTION
I want to use a MongoDB `GridFileSystem` as a source of images for Compass, and need to be able to analyze the images in the filesystem for dimension information. This patch provides the configuration parameter `images_file_source`, which accepts a `Proc` or `lambda` that accepts the path of the file to be analyzed and returns an `IO`-like object that can be used in the `ImageProperties` analysis. With this setup, using a `GridFileSystem` source for image data can be done like this:

``` ruby
require 'forwardable'

class CompassGridIO
  extend Forwardable

  def initialize(io)
    @io = io
  end

  def_delegators :@io, :read, :close

  def readbyte
    @io.getc.bytes.first
  end
end

Compass.configuration.images_file_source = lambda { |file|
  file = file.gsub(%r{^[\./]+}, '') # got to rip off any leading path characters

  CompassGridIO.new(grid_file_system.open(file, 'r'))
}
```

Having a file in `grid_file_system` at, say, `file.jpg`, will be accessed correctly when using any of the image-size methods in Sass:

``` scss
#logo {
  width: image-width('file.jpg');
  height: image-height('file.jpg');
  background: image-url('file.jpg');
}
```
