### PR TITLE
Add Code Climate badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,6 +2,8 @@
 
 Build Status: ![Build Status](https://secure.travis-ci.org/chriseppstein/compass.png)
 
+Code Quality: [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/chriseppstein/compass)
+
 ## Resources
 
 * [Compass Homepage](http://compass-style.org/)


### PR DESCRIPTION
Per discussion with @chriseppstein, I setup Compass as an early access project for Code Climate's in-development free-for-OSS support.
