### PR TITLE
Fixed syntax error

### DIFF
--- a/lib/compass/sass_extensions/functions/sprites.rb
+++ b/lib/compass/sass_extensions/functions/sprites.rb
@@ -189,7 +189,6 @@ module Compass::SassExtensions::Functions::Sprites
     image.position
   end
   Sass::Script::Functions.declare :sprite_image_position, [:map, :sprite]
-end
 
 protected
 


### PR DESCRIPTION
Syntax error was introduced in the [previous commit](https://github.com/chriseppstein/compass/blob/f562f4855d1e290ac70605063f096a473af4bb5c/lib/compass/sass_extensions/functions/sprites.rb#L192) (`end` keyword on line 192)
