### PR TITLE
Fix hyphenation doc

### DIFF
--- a/doc-src/content/reference/compass/css3/hyphenation.haml
+++ b/doc-src/content/reference/compass/css3/hyphenation.haml
@@ -1,9 +1,9 @@
---- 
-title: Compass Hyphenate
-crumb: Hyphenate
+---
+title: Compass Hyphenation
+crumb: Hyphenation
 framework: compass
-stylesheet: compass/css3/_hyphenate.scss
-meta_description: Mixin for breaking space and injecting hypens into overflowing text
+stylesheet: compass/css3/_hyphenation.scss
+meta_description: Mixin for breaking space and injecting hyphens into overflowing text
 layout: core
 classnames:
   - reference


### PR DESCRIPTION
While working on #936 I had trouble getting the docs to compile. They were looking for the stylesheet `compass/css3/_hyphenate` instead of `compass/css3/_hyphenation`. I updated the docs to reference the correct stylesheet and moved the file to `hyphenation.haml`. In the process I also fixed a typo (`/s/hypens/hyphens`).
