### PR TITLE
Sprite archetype

### DIFF
--- a/doc-src/content/help/tutorials/spriting/customization-options.markdown
+++ b/doc-src/content/help/tutorials/spriting/customization-options.markdown
@@ -29,6 +29,8 @@ the sprites were contained within a folder called `icon`.
   included in each sprite's CSS output. Can be `true` or `false`. Defaults to `false`.
 * `$<map>-sprite-base-class` -- The base class for these sprites. Defaults to `.<map>-sprite`.
   E.g. `$icon-sprite-base-class: ".action-icon"`
+* `$<map>-sprite-archetype` -- The name of a single sprite image to use for default width and
+  height values. No default value. E.g. `$icon-sprite-archetype: "twitter"`
 * `$<map>-clean-up` -- Whether or not to removed the old sprite file when a new one is created. Defaults to true
 
 ### Options per Sprite

--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -45,7 +45,7 @@ $<%= name %>-inline: false !default;
     background: $<%= name %>-sprites no-repeat;
   }
 }
-//sass functions to return the dimensions of a sprite image as units
+// Sass functions to return the dimensions of a sprite image as units
 <% [:width, :height].each do |dimension| %>
   @function <%= name %>-sprite-<%= dimension %>($name) {
     $file: sprite_file($<%= name %>-sprites, $name);

--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -11,6 +11,7 @@ $<%= name %>-prefix: '' !default;
 $<%= name %>-clean-up: true !default;
 $<%= name %>-layout:vertical !default;
 $<%= name %>-inline: false !default;
+$<%= name %>-sprite-archetype: '' !default;
 
 <% if skip_overrides %> 
   $<%= name %>-sprites: sprite-map("<%= uri %>", $layout: $<%= name %>-layout, $cleanup: $<%= name %>-clean-up);
@@ -34,17 +35,6 @@ $<%= name %>-inline: false !default;
  );
 <% end %>
 
-// All sprites should extend this class
-// The <%= name %>-sprite mixin will do so for you.
-@if $<%= name %>-inline {
-  #{$<%= name %>-sprite-base-class} {
-    background-image: inline-sprite($<%= name %>-sprites);
-  } 
-} @else {
-  #{$<%= name %>-sprite-base-class} {
-    background: $<%= name %>-sprites no-repeat;
-  }
-}
 // Sass functions to return the dimensions of a sprite image as units
 <% [:width, :height].each do |dimension| %>
   @function <%= name %>-sprite-<%= dimension %>($name) {
@@ -52,6 +42,20 @@ $<%= name %>-inline: false !default;
     @return image-<%= dimension %>($file);
   }
 <% end %>
+
+// All sprites should extend this class
+// The <%= name %>-sprite mixin will do so for you.
+#{$<%= name %>-sprite-base-class} {
+  @if $<%= name %>-inline {
+    background-image: inline-sprite($<%= name %>-sprites);
+  } @else {
+    background: $<%= name %>-sprites no-repeat;
+  }
+  @if $<%= name %>-sprite-archetype {
+    width: <%= name %>-sprite-width($<%= name %>-sprite-archetype);
+    height: <%= name %>-sprite-height($<%= name %>-sprite-archetype);
+  }
+}
 
 // Use this to set the dimensions of an element
 // based on the size of the original image.

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -137,6 +137,30 @@ class SpritesTest < Test::Unit::TestCase
     assert_equal image_size('squares-s*.png'), [20, 30]
   end
 
+  it "should generate sprite classes with width and height of archetype sprite, the yellow sprite" do
+    css = render <<-SCSS
+      $colors-sprite-archetype: yellow;
+      @import "colors/*.png";
+      @include all-colors-sprites;
+    SCSS
+    assert_correct css, <<-CSS
+      .colors-sprite, .colors-blue, .colors-yellow {
+        background: url('/colors-sbbc18e2129.png') no-repeat;
+        height: 10px;
+        width: 10px;
+      }
+      
+      .colors-blue {
+        background-position: 0 0;
+      }
+      
+      .colors-yellow {
+        background-position: 0 -10px;
+      }
+    CSS
+    assert_equal image_size('colors-s*.png'), [20, 30]
+  end
+
   it "should provide sprite mixin" do
     css = render <<-SCSS
       @import "squares/*.png";


### PR DESCRIPTION
When a group of sprites all have the same width and height there is no clean way to only output the common width and height with the main `.<name>-sprite` class. The `$<name>-sprite-archetype` variable offers the ability for a user to specify a sprite from which the user can set the base width and height of the sprite.

Room for improvement: auto detect a common size of sprites and optionally output width and height if all sprites have the same dimensions.

(Sorry, this branch doesn't pass tests, couldn't figure out how to determine the correct generated sprite map file name to place into the test)
