### PR TITLE
Fix invalid method call for strip_trailing_seperator in configuration

### DIFF
--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -74,7 +74,7 @@ module Compass
       Data.send(:define_method, :"default_#{name}", &default) if default
       Data.inherited_accessor(name)
       if name.to_s =~ /dir|path/
-        strip_trailing_separator(name)
+        Data.strip_trailing_separator(name)
       end
     end
 


### PR DESCRIPTION
Fix `strip_trailing_seperator` method call when adding custom configuration method.
