### PR TITLE
Added support for display: (-prefix-?)inline-box;

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_box.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_box.scss
@@ -1,8 +1,13 @@
 @import "shared";
 
-// display:box; must be used for any of the other flexbox mixins to work properly
-@mixin display-box {
-  @include experimental-value(display, box,
+// display:(inline-?)box; must be used for any of the other flexbox mixins to work properly
+@mixin display-box( $box-style: box ) {
+  // box is default
+  @if $box-style != inline-box
+  {
+    $box-style: box;
+  }
+  @include experimental-value(display, $box-style,
     -moz, -webkit, not -o, -ms, not -khtml, official
   );
 }


### PR DESCRIPTION
The whole Flexbox implementation needs rewriting because [the W3C has changed the syntax](http://www.w3.org/TR/css3-flexbox/) (again). As I have time, I hope to work on it, but in the meantime, here’s support for box or inline-box.
