### PR TITLE
Replace #root_footer with :after pseudo-element

### DIFF
--- a/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
+++ b/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
@@ -6,7 +6,7 @@
 //
 // Footer must be a fixed height.
 
-@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer")) {
+@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $footer-selector: unquote("#footer")) {
   html, body {
     height: 100%; }
   #{$root-selector} {
@@ -15,7 +15,9 @@
     height: auto !important;
     height: 100%;
     margin-bottom: -$footer-height;
-    #{$root-footer-selector} {
+    &:after {
+      content: "";
+      display: block;
       height: $footer-height; } }
   #{$footer-selector} {
     clear: both;

--- a/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
+++ b/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
@@ -6,7 +6,7 @@
 //
 // Footer must be a fixed height.
 
-@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $footer-selector: unquote("#footer")) {
+@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("&:after"), $footer-selector: unquote("#footer")) {
   html, body {
     height: 100%; }
   #{$root-selector} {
@@ -15,7 +15,7 @@
     height: auto !important;
     height: 100%;
     margin-bottom: -$footer-height;
-    &:after {
+    #{$root-footer-selector} {
       content: "";
       display: block;
       height: $footer-height; } }


### PR DESCRIPTION
We can remove the extra markup element and have a cleaner HTML structure.
The downside is that a user-defined pseudo-element of the #root can interfere with the sticky-footer one.
