### PR TITLE
Feature/add documentation for selection mixin

### DIFF
--- a/doc-src/Gemfile.lock
+++ b/doc-src/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: ..
   specs:
-    compass (0.13.alpha.0.d876868)
+    compass (0.13.alpha.0.d4db12f)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (~> 3.2.0.alpha.93)

--- a/doc-src/content/examples/compass/css3/selection.haml
+++ b/doc-src/content/examples/compass/css3/selection.haml
@@ -1,0 +1,8 @@
+---
+title: CSS3 Selection Example
+description: css3 mixin for selection
+framework: compass
+stylesheet: compass/css3/_selection.scss
+example: true
+---
+= render "partials/example"

--- a/doc-src/content/examples/compass/css3/selection/markup.haml
+++ b/doc-src/content/examples/compass/css3/selection/markup.haml
@@ -1,0 +1,2 @@
+.example
+  %p Highlight this line to see the changes.

--- a/doc-src/content/examples/compass/css3/selection/stylesheet.sass
+++ b/doc-src/content/examples/compass/css3/selection/stylesheet.sass
@@ -1,0 +1,7 @@
+@import compass/css3/selection
+
+.example
+  p
+    @include selection 
+      color: #fff
+      background-color: #ff5e99

--- a/doc-src/content/reference/compass/css3/selection.haml
+++ b/doc-src/content/reference/compass/css3/selection.haml
@@ -1,0 +1,14 @@
+--- 
+title: Compass Selection
+crumb: Selection
+framework: compass
+stylesheet: compass/css3/_selection.scss
+meta_description: Specify selection styles for supported browsers.
+layout: core
+classnames:
+  - reference
+  - core
+  - css3
+---
+- render 'reference' do
+  %p Provides cross-browser CSS selection styles. 

--- a/frameworks/compass/stylesheets/compass/css3/_selection.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_selection.scss
@@ -1,15 +1,37 @@
-// Add the selection selector to any element
-// Example:
-// @include selection {
-//   color: #fff;
-//   background-color: #ff5e99;
-// }
 
+// ----------------------------------------------------------------------------
+// Add the selection selector to any element
+//
+// Examples:
+//
+//     p {
+//        @include selection {
+//          color: #fff;
+//          background-color: #ff5e99;
+//        }
+//     }
+// Which generates:
+//
+//     p::-moz-selection {
+//       color: white;
+//       background-color: #ff5e99; }
+//
+// Caveat: keep in mind that, due to the implementation,
+// always include the mixin under a parent element.
+// If you need the selection styles all around,
+// put it under * like so:
+// 
+//     * {
+//        @include selection {
+//          color: #fff;
+//          background-color: #ff5e99;
+//        }
+//     }
 @mixin selection {
-  ::selection {
+  &::selection {
     @content;
   }
-  ::-moz-selection {
+  &::-moz-selection {
     @content;
   }
 }


### PR DESCRIPTION
I also changed the implementation to use the parent selector for proper inheritance. Caveat is that you can't use the mixin alone(it's also included in the docs)
