### PR TITLE
Add ability to set clear direction in pie-clearfix.

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/general/_clearfix.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/general/_clearfix.scss
@@ -34,11 +34,11 @@
 // If you need to support Firefox before 3.5 you need to use `legacy-pie-clearfix` instead.
 //
 // Adapted from: [A new micro clearfix hack](http://nicolasgallagher.com/micro-clearfix-hack/)
-@mixin pie-clearfix {
+@mixin pie-clearfix($clear: both) {
   &:after {
     content: "";
     display: table;
-    clear: both;
+    clear: $clear;
   }
   @include has-layout;
 }


### PR DESCRIPTION
Add argument to pie-clearfix mixin for clear direction. Defaults to 'both'.

Sometimes you need to be able to set this to not blow up floated layouts.
