### PR TITLE
Bug fix for CSS gradient parsing.

### DIFF
--- a/doc-src/content/CHANGELOG.markdown
+++ b/doc-src/content/CHANGELOG.markdown
@@ -17,6 +17,7 @@ The Documentation for the [latest preview release](http://beta.compass-style.org
 0.13.alpha.1 (UNRELEASED)
 -------------------------
 
+* Fix a bug in gradients that used the currentColor keyword
 * Removed the -ms prefix support from keyfrome animation, the spec was
   approved before MS released IE10.
 

--- a/test/fixtures/stylesheets/compass/css/gradients.css
+++ b/test/fixtures/stylesheets/compass/css/gradients.css
@@ -72,7 +72,7 @@
   background-image: linear-gradient(left, #dddddd 10px, #aaaaaa 40px); }
 
 .transparent-in-linear-gradient {
-  background-image: white url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iInRyYW5zcGFyZW50IiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2FhYWFhYSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
+  background-image: white url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iYmxhY2siIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2FhYWFhYSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA==');
   background-size: 100%;
   background-image: white -webkit-gradient(linear, 0% 0%, 100% 100%, color-stop(0%, transparent), color-stop(100%, #aaaaaa));
   background-image: white -webkit-linear-gradient(top left, transparent, #aaaaaa);
@@ -80,14 +80,41 @@
   background-image: white -o-linear-gradient(top left, transparent, #aaaaaa);
   background-image: white linear-gradient(top left, transparent, #aaaaaa); }
 
+.currentColor-in-linear-gradient {
+  background-image: white url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iYmxhY2siIHN0b3Atb3BhY2l0eT0iMCIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iY3VycmVudENvbG9yIi8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
+  background-size: 100%;
+  background-image: white -webkit-gradient(linear, 0% 0%, 100% 100%, color-stop(0%, transparent), color-stop(100%, currentColor));
+  background-image: white -webkit-linear-gradient(top left, transparent, currentColor);
+  background-image: white -moz-linear-gradient(top left, transparent, currentColor);
+  background-image: white -o-linear-gradient(top left, transparent, currentColor);
+  background-image: white linear-gradient(top left, transparent, currentColor); }
+
+.rgba-in-linear-gradient {
+  background-image: white url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIgc3RvcC1vcGFjaXR5PSIwLjgiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMwMDAwMDAiIHN0b3Atb3BhY2l0eT0iMC4xIi8+PC9saW5lYXJHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
+  background-size: 100%;
+  background-image: white -webkit-gradient(linear, 0% 0%, 100% 100%, color-stop(0%, rgba(255, 255, 255, 0.8)), color-stop(100%, rgba(0, 0, 0, 0.1)));
+  background-image: white -webkit-linear-gradient(top left, rgba(255, 255, 255, 0.8), rgba(0, 0, 0, 0.1));
+  background-image: white -moz-linear-gradient(top left, rgba(255, 255, 255, 0.8), rgba(0, 0, 0, 0.1));
+  background-image: white -o-linear-gradient(top left, rgba(255, 255, 255, 0.8), rgba(0, 0, 0, 0.1));
+  background-image: white linear-gradient(top left, rgba(255, 255, 255, 0.8), rgba(0, 0, 0, 0.1)); }
+
 .bg-radial-gradient {
-  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY3g9IjUwJSIgY3k9IjUwJSIgcj0iMTAwIj48c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjZGRkZGRkIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIidHJhbnNwYXJlbnQiIi8+PC9yYWRpYWxHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY3g9IjUwJSIgY3k9IjUwJSIgcj0iMTAwIj48c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjZGRkZGRkIi8+PHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSJibGFjayIgc3RvcC1vcGFjaXR5PSIwIi8+PC9yYWRpYWxHcmFkaWVudD48L2RlZnM+PHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
   background-size: 100%;
   background-image: -webkit-gradient(radial, 50% 50%, 0, 50% 50%, 100, color-stop(0%, #dddddd), color-stop(100%, transparent));
   background-image: -webkit-radial-gradient(center center, #dddddd, transparent 100px);
   background-image: -moz-radial-gradient(center center, #dddddd, transparent 100px);
   background-image: -o-radial-gradient(center center, #dddddd, transparent 100px);
   background-image: radial-gradient(center center, #dddddd, transparent 100px); }
+
+.currentColor-in-radial-gradient {
+  background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHJhZGlhbEdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgY3g9IjUwJSIgY3k9IjUwJSIgcj0iMTAwIj48c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSJjdXJyZW50Q29sb3IiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9ImJsYWNrIiBzdG9wLW9wYWNpdHk9IjAiLz48L3JhZGlhbEdyYWRpZW50PjwvZGVmcz48cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyYWQpIiAvPjwvc3ZnPiA=');
+  background-size: 100%;
+  background-image: -webkit-gradient(radial, 50% 50%, 0, 50% 50%, 100, color-stop(0%, currentColor), color-stop(100%, transparent));
+  background-image: -webkit-radial-gradient(center center, currentColor, transparent 100px);
+  background-image: -moz-radial-gradient(center center, currentColor, transparent 100px);
+  background-image: -o-radial-gradient(center center, currentColor, transparent 100px);
+  background-image: radial-gradient(center center, currentColor, transparent 100px); }
 
 .bg-linear-gradient-with-angle {
   background-image: -webkit-linear-gradient(-45deg, #dddddd, #aaaaaa);

--- a/test/fixtures/stylesheets/compass/sass/gradients.sass
+++ b/test/fixtures/stylesheets/compass/sass/gradients.sass
@@ -34,8 +34,17 @@ $experimental-support-for-svg: true
 .transparent-in-linear-gradient
   +background-image(#fff linear-gradient(top left, transparent, #aaa))
 
+.currentColor-in-linear-gradient
+  +background-image(#fff linear-gradient(top left, transparent, currentColor))
+
+.rgba-in-linear-gradient
+  +background-image(#fff linear-gradient(top left, rgba(255,255,255,0.8), rgba(0,0,0,0.1)))
+
 .bg-radial-gradient
   +background-image(radial-gradient(center center, #ddd, transparent 100px))
+
+.currentColor-in-radial-gradient
+  +background-image(radial-gradient(center center, currentColor, transparent 100px))
 
 .bg-linear-gradient-with-angle
   +background-image(linear-gradient(-45deg, #ddd, #aaa))


### PR DESCRIPTION
The string "currentColor" is a valid color for gradients.  Before this patch, using it in a gradient definition gave the following error and backtrace:

 Syntax error: Expected a color. Got: currentColor
        on line 487 of /home/cananian/Projects/OLPC/Narrative/nell-colors/sass/b
rushdemo.scss

Backtrace:
/home/cananian/Projects/OLPC/Narrative/nell-colors/sass/brushdemo.scss:487
/home/cananian/Projects/OLPC/Narrative/compass/lib/compass/sass_extensions/funct
ions/gradient_support.rb:14:in `initialize'
/home/cananian/Projects/OLPC/Narrative/compass/lib/compass/sass_extensions/funct
ions/gradient_support.rb:252:in`new'
/home/cananian/Projects/OLPC/Narrative/compass/lib/compass/sass_extensions/funct
ions/gradient_support.rb:252:in `block in color_stops'
/home/cananian/Projects/OLPC/Narrative/compass/lib/compass/sass_extensions/funct
ions/gradient_support.rb:246:in`map'
/home/cananian/Projects/OLPC/Narrative/compass/lib/compass/sass_extensions/funct
ions/gradient_support.rb:246:in `color_stops'
/home/cananian/Projects/OLPC/Narrative/compass/lib/compass/sass_extensions/funct
ions/gradient_support.rb:303:in`linear_gradient'
/usr/lib/ruby/vendor_ruby/sass/script/funcall.rb:88:in `_perform'
/usr/lib/ruby/vendor_ruby/sass/script/node.rb:40:in`perform'
/usr/lib/ruby/vendor_ruby/sass/tree/visitors/perform.rb:216:in `visit_prop'
/usr/lib/ruby/vendor_ruby/sass/tree/visitors/base.rb:37:in`visit'
