### PR TITLE
Improve flexibility of input-placeholder mixin so it can be used at the ...

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
@@ -31,18 +31,18 @@
 //
 //     .textinput {
 //       @include input-placeholder("&") {
-//       	 color: #bfbfbf;
-//       	 font-style: italic;
+//         color: #bfbfbf;
+//         font-style: italic;
 //       }
 //     }
 @mixin input-placeholder($selector: "") {
-	@if $experimental-support-for-webkit {
-		#{$selector}::-webkit-input-placeholder { @content; }
-	}
-	@if $experimental-support-for-mozilla {
-		#{$selector}:-moz-placeholder { @content; }
-	}
-	@if $experimental-support-for-microsoft {
-		#{$selector}:-ms-input-placeholder { @content; }
-	}
+  @if $experimental-support-for-webkit {
+    #{$selector}::-webkit-input-placeholder { @content; }
+  }
+  @if $experimental-support-for-mozilla {
+    #{$selector}:-moz-placeholder { @content; }
+  }
+  @if $experimental-support-for-microsoft {
+    #{$selector}:-ms-input-placeholder { @content; }
+  }
 }

--- a/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
@@ -18,21 +18,31 @@
 
 // Style the html5 input placeholder in browsers that support it.
 //
-// The styles for the input placeholder are passed as mixin content.
-// For example:
+// There are two usage modes: at the stylesheet root, include the mixin with
+// styles passed as mixin content. This applies to all elements. For example:
 //
 //     @include input-placeholder {
 //       color: #bfbfbf;
 //       font-style: italic;
 //     }
-@mixin input-placeholder {
+//
+// If a specific element is being styled, pass "&" as an argument to the mixin
+// as well. For example:
+//
+//     .textinput {
+//       @include input-placeholder("&") {
+//       	 color: #bfbfbf;
+//       	 font-style: italic;
+//       }
+//     }
+@mixin input-placeholder($selector: "") {
 	@if $experimental-support-for-webkit {
-		&::-webkit-input-placeholder { @content; }
+		#{$selector}::-webkit-input-placeholder { @content; }
 	}
 	@if $experimental-support-for-mozilla {
-		&:-moz-placeholder { @content; }
+		#{$selector}:-moz-placeholder { @content; }
 	}
 	@if $experimental-support-for-microsoft {
-		&:-ms-input-placeholder { @content; }
+		#{$selector}:-ms-input-placeholder { @content; }
 	}
 }

--- a/test/fixtures/stylesheets/compass/css/user-interface.css
+++ b/test/fixtures/stylesheets/compass/css/user-interface.css
@@ -3,6 +3,16 @@
   -moz-user-select: none;
   user-select: none; }
 
+::-webkit-input-placeholder {
+  color: #bfbfbf;
+  font-style: italic; }
+:-moz-placeholder {
+  color: #bfbfbf;
+  font-style: italic; }
+:-ms-input-placeholder {
+  color: #bfbfbf;
+  font-style: italic; }
+
 .input-placeholder::-webkit-input-placeholder {
   color: #bfbfbf;
   font-style: italic; }

--- a/test/fixtures/stylesheets/compass/sass/user-interface.scss
+++ b/test/fixtures/stylesheets/compass/sass/user-interface.scss
@@ -5,13 +5,13 @@
 }
 
 @include input-placeholder {
-	color: #bfbfbf;
-	font-style: italic;
+  color: #bfbfbf;
+  font-style: italic;
 }
 
 .input-placeholder {
-	@include input-placeholder("&") {
-		color: #bfbfbf;
-		font-style: italic;
-	}
+  @include input-placeholder("&") {
+    color: #bfbfbf;
+    font-style: italic;
+  }
 }

--- a/test/fixtures/stylesheets/compass/sass/user-interface.scss
+++ b/test/fixtures/stylesheets/compass/sass/user-interface.scss
@@ -4,8 +4,13 @@
   @include user-select(none);
 }
 
+@include input-placeholder {
+	color: #bfbfbf;
+	font-style: italic;
+}
+
 .input-placeholder {
-	@include input-placeholder {
+	@include input-placeholder("&") {
 		color: #bfbfbf;
 		font-style: italic;
 	}


### PR DESCRIPTION
...root of the stylesheet or with an argument for use with a selector.

This creates two usage mode: at the stylesheet root, include the mixin with styles passed as mixin content. If a specific element is being styled, pass "&" as an argument to the mixin as well.

Addresses #1035, should be consistent with the solution for #1021. Note this changes the default behaviour of this mixin. Authors would need to update stylesheets, but this is not in stable yet, so that shouldn't be an issue.
