### PR TITLE
Update css3 selection mixin for flexibility and consistency, add tests

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_selection.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_selection.scss
@@ -1,15 +1,31 @@
-// Add the selection selector to any element
-// Example:
-// @include selection {
-//   color: #fff;
-//   background-color: #ff5e99;
-// }
+@import "shared";
 
-@mixin selection {
-  ::selection {
+// Add the selection selector to any element
+//
+// There are two usage modes: at the stylesheet root, include the mixin with
+// styles passed as mixin content. This applies to all elements. For example:
+//
+//     @include selection {
+//       background-color: #fe57a1;
+//       color: #fff;
+//     }
+//
+// If a specific element is being styled, pass "&" as an argument to the mixin
+// as well. For example:
+//
+//     .hot-pink {
+//       @include selection("&") {
+//         background-color: #fe57a1;
+//         color: #fff;
+//       }
+//     }
+@mixin selection($selector: "") {
+  #{$selector}::selection {
     @content;
   }
-  ::-moz-selection {
-    @content;
+  @if $experimental-support-for-mozilla {
+    #{$selector}::-moz-selection {
+      @content;
+    }
   }
 }

--- a/test/fixtures/stylesheets/compass/css/selection.css
+++ b/test/fixtures/stylesheets/compass/css/selection.css
@@ -1,0 +1,13 @@
+::selection {
+  background-color: #fe57a1;
+  color: #fff; }
+::-moz-selection {
+  background-color: #fe57a1;
+  color: #fff; }
+
+.hot-pink::selection {
+  background-color: #fe57a1;
+  color: #fff; }
+.hot-pink::-moz-selection {
+  background-color: #fe57a1;
+  color: #fff; }

--- a/test/fixtures/stylesheets/compass/sass/selection.scss
+++ b/test/fixtures/stylesheets/compass/sass/selection.scss
@@ -1,0 +1,13 @@
+@import "compass/css3/selection";
+
+@include selection {
+  background-color: #fe57a1;
+  color: #fff;
+}
+
+.hot-pink {
+  @include selection("&") {
+    background-color: #fe57a1;
+    color: #fff;
+  }
+}


### PR DESCRIPTION
- Added missing tests.
- Now respects $experimental-support-for-mozilla.
- Takes an argument ("&") to work with selectors; by default works at the stylesheet root with no argument.
- Previous point is for consistency with #1044.
