### PR TITLE
Change "log" to "logarithm" in the docs

### DIFF
--- a/doc-src/content/reference/compass/helpers.haml
+++ b/doc-src/content/reference/compass/helpers.haml
@@ -36,7 +36,7 @@ layout: core
   * [image-url()](/reference/compass/helpers/urls/#image-url)
   * [inline-font-files()](/reference/compass/helpers/inline-data/#inline-font-files)
   * [inline-image()](/reference/compass/helpers/inline-data/#inline-image)
-  * [log()](/reference/compass/helpers/math/#log)
+  * [logarithm()](/reference/compass/helpers/math/#logarithm)
   * [nest()](/reference/compass/helpers/selectors/#nest)
   * [pow()](/reference/compass/helpers/math/#pow)
   * [prefix()](/reference/compass/helpers/cross-browser/#prefix)

--- a/doc-src/content/reference/compass/helpers/math.haml
+++ b/doc-src/content/reference/compass/helpers/math.haml
@@ -14,7 +14,7 @@ documented_functions:
   - "cos"
   - "tan"
   - "e"
-  - "log"
+  - "logarithm"
   - "sqrt"
   - "pow"
 ---
@@ -76,10 +76,10 @@ documented_functions:
     %p
       Returns the value of <a href="http://en.wikipedia.org/wiki/E_(mathematical_constant)">e</a>.
 
-#log.helper
+#logarithm.helper
   %h3
-    %a(href="#log")
-      log(<span class="arg">$number</span>, <span class="arg" data-default-value="e" title="Defaults to: e">$base</span>)
+    %a(href="#logarithm")
+      logarithm(<span class="arg">$number</span>, <span class="arg" data-default-value="e" title="Defaults to: e">$base</span>)
   .details
     %p
       Calculates the logarithm of a number to a base. Base defaults to <code>e</code>.


### PR DESCRIPTION
It seems that whoever renamed `log` to `logarithm` forgot to do the same in the docs.

This fixes issue #1049.
