### PR TITLE
:filename requires string replacement. Closes #989

### DIFF
--- a/lib/compass/compiler.rb
+++ b/lib/compass/compiler.rb
@@ -152,7 +152,8 @@ module Compass
     # A sass engine for compiling a single file.
     def engine(sass_filename, css_filename)
       syntax = (sass_filename =~ /\.(s[ac]ss)$/) && $1.to_sym || :sass
-      opts = sass_options.merge(:filename => sass_filename, :css_filename => css_filename, :syntax => syntax)
+      filename = sass_filename.gsub(%r{.*((/[^/]+){4})}, '\1')
+      opts = sass_options.merge(:filename => filename, :css_filename => css_filename, :syntax => syntax)
       Sass::Engine.new(open(sass_filename).read, opts)
     end
 


### PR DESCRIPTION
This commit definitely solves the problem, absolute and relative paths work on second compile and debugger reports proper paths, however I am not entirely sure WHY it solves the problem, so it needs review. 
