### PR TITLE
Fix Travis build badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: ruby
+
 rvm:
   - 1.8.7
   - 1.9.2
@@ -5,4 +7,7 @@ rvm:
   - jruby
   - rbx
   - ree
-script: "bundle exec rake test features"
+
+test: 
+  - bundle exec rake test
+  - bundle exec rake features

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,19 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - jruby
-  - rbx
+  - ruby-head
   - ree
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
+  - rbx-18mode
+  - rbx-19mode
 
 test: 
   - bundle exec rake test
   - bundle exec rake features
+  
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Compass Stylesheet Authoring Framework
 
-Build Status: ![Build Status](https://secure.travis-ci.org/chriseppstein/compass.png)
+Build Status: [![Build Status](https://secure.travis-ci.org/chriseppstein/compass.png)](http://travis-ci.org/chriseppstein/compass)
 
 Code Quality: [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/chriseppstein/compass)
 


### PR DESCRIPTION
- Travis badge now correctly links to build page
- the .travis.yml changes to a larger build matrix
