### PR TITLE
Fix typo in `compass compile` help

### DIFF
--- a/lib/compass/commands/update_project.rb
+++ b/lib/compass/commands/update_project.rb
@@ -9,7 +9,7 @@ module Compass
           Usage: compass compile [path/to/project] [path/to/project/src/file.sass ...] [options]
 
           Description:
-          compile project at the path specified or the current director if not specified.
+          compile project at the path specified or the current directory if not specified.
 
           Options:
         }.split("\n").map{|l| l.gsub(/^ */,'')}.join("\n")


### PR DESCRIPTION
Change 'director' to 'directory' in help content
