### PR TITLE
Fix the duck typing to support the Hashery gem

### DIFF
--- a/lib/compass/configuration/helpers.rb
+++ b/lib/compass/configuration/helpers.rb
@@ -33,6 +33,8 @@ module Compass
           nil
         elsif config.is_a?(Compass::Configuration::Data)
           config
+        elsif config.instance_of?(Hash)
+          Compass::Configuration::Data.new(filename, config)
         elsif config.respond_to?(:read)
           filename ||= config.to_s if config.is_a?(Pathname)
           Compass::Configuration::FileData.new_from_string(config.read, filename, defaults)


### PR DESCRIPTION
This pull request makes Compass compatible with Hashery. The Hashery gem defines a "read" method in the Hash class, so Compass duck typing thinks it's an IO object and blows up when it tries to read it. I added a new condition to the type check to see if the config is actually a Hash (using instance_of, not is_a) before checking if it's an IO object.
