### PR TITLE
Add support for positioning sprites with percentages

### DIFF
--- a/doc-src/content/help/tutorials/best_practices.markdown
+++ b/doc-src/content/help/tutorials/best_practices.markdown
@@ -65,7 +65,7 @@ webpage content. Following this best practice theoretically results in a website
 that is easier to maintain. However, in reality, the functional limitations of
 CSS force abstractions down into the markup to facilitate the [DRY][4] principle
 of code maintainability. Sass allows us to move our presentation completely to
-the stylesheets because it let's us create abstractions and reuse entirely in
+the stylesheets because it lets us create abstractions and reuse entirely in
 that context. Read [this blog post][5] for more information on the subject.
 
 Once you have clean markup, style it using Mixins and Inheritance. With clean

--- a/doc-src/content/help/tutorials/integration.markdown
+++ b/doc-src/content/help/tutorials/integration.markdown
@@ -48,13 +48,13 @@ Check out this [sample compass-sinatra project](http://github.com/chriseppstein/
 
 [Sinatra Bootstrap](http://github.com/adamstac/sinatra-bootstrap) - a base Sinatra project with support for Haml, Sass, Compass, jQuery and more.
 
-## Nanoc3
+## nanoc
 
 ### Minimal integration: just drop it in
 
-One simple route for lightweight integration is to simply install compass inside nanoc. Then edit config.rb to point to the stylesheets you want to use. This means you have to have the Compass watch command running in a separate window from the Nanoc compilation process. 
+One simple route for lightweight integration is to simply install compass inside nanoc. Then edit `config.rb` to point to the stylesheets you want to use. This means you have to have the Compass watch command running in a separate window from the Nanoc compilation process. 
 
-Example project that works this way: http://github.com/unthinkingly/unthinkingly-blog
+Example project that works this way: [unthinkingly](http://github.com/unthinkingly/unthinkingly-blog).
 
 ### More formal integration
 
@@ -62,10 +62,13 @@ At the top of the Nanoc Rules file, load the Compass configuration, like this:
 
     require 'compass'
 
-    Compass.add_project_configuration 'compass.rb' # when using Compass > 0.10
-    Compass.configuration.parse 'compass.rb'       # when using Compass < 0.10
+    Compass.add_project_configuration 'compass.rb'        # when using Compass > 0.10
+    sass_options = Compass.sass_engine_options            # when using Compass > 0.10
 
-Your Compass configuration file (in compass/config.rb) could look like this (you may need to change the path to some directories depending on your directory structure):
+    Compass.configuration.parse 'compass.rb'              # when using Compass < 0.10
+    sass_options = Compass.config.to_sass_engine_options  # when using Compass < 0.10
+
+Then create a `compass.rb` file in your site's root folder and add your Compass configuration. An example configuration could look like this:
 
     http_path = "/"
     project_path = File.expand_path(File.join(File.dirname(__FILE__), '..'))
@@ -79,6 +82,7 @@ Your Compass configuration file (in compass/config.rb) could look like this (you
     http_images_dir = "images"
     http_fonts_dir = "fonts"
 
+You may need to change the path to some directories depending on your directory structure and the setup in your Rules file.
 
 To filter the stylesheets using Sass and Compass, call the sass filter with Sass engine options taken from Compass, like this:
 
@@ -87,6 +91,6 @@ To filter the stylesheets using Sass and Compass, call the sass filter with Sass
     end
 
 
-### Nanoc Projects using the formal approach
+### nanoc projects using the formal approach
 
 * [This Site](https://github.com/chriseppstein/compass/tree/master/doc-src)

--- a/doc-src/content/help/tutorials/integration.markdown
+++ b/doc-src/content/help/tutorials/integration.markdown
@@ -28,14 +28,14 @@ Also checkout this [gist](https://gist.github.com/1184843)
     require 'haml'
 
     configure do
-      set :haml, {:format => :html5, :escape_html => true}
+      set :haml, {:format => :html5}
       set :scss, {:style => :compact, :debug_info => false}
       Compass.add_project_configuration(File.join(Sinatra::Application.root, 'config', 'compass.rb'))
     end
 
     get '/stylesheets/:name.css' do
       content_type 'text/css', :charset => 'utf-8'
-      scss(:"stylesheets/#{params[:name]}" )
+      scss :"stylesheets/#{params[:name]}", Compass.sass_engine_options
     end
 
     get '/' do
@@ -43,7 +43,7 @@ Also checkout this [gist](https://gist.github.com/1184843)
     end
 
 
-If you keep your stylesheets in “views/stylesheets/” directory instead of just “views/”, remember to update sass_dir configuration accordingly.
+This assumes you keep your Compass config file in `config/compass.rb`. If you keep your stylesheets in “views/stylesheets/” directory instead of just “views/”, remember to update `sass_dir` configuration accordingly.
 Check out this [sample compass-sinatra project](http://github.com/chriseppstein/compass-sinatra) to get up and running in no time!
 
 [Sinatra Bootstrap](http://github.com/adamstac/sinatra-bootstrap) - a base Sinatra project with support for Haml, Sass, Compass, jQuery and more.

--- a/doc-src/content/reference/compass/helpers/sprites.haml
+++ b/doc-src/content/reference/compass/helpers/sprites.haml
@@ -77,7 +77,7 @@ documented_functions:
 #sprite.helper
   %h3
     %a(href="#sprite")
-      sprite(<span class="arg">$map</span>, <span class="arg">$sprite</span>, <span class="arg" data-default-value="0">$offset-x</span>, <span class="arg" data-default-value="0">$offset-y</span>)
+      sprite(<span class="arg">$map</span>, <span class="arg">$sprite</span>, <span class="arg" data-default-value="0">$offset-x</span>, <span class="arg" data-default-value="0">$offset-y</span>, <span class="arg" data-default-value="false">$use-percentages</span>)
   .details
     :markdown
       Returns the image and background position for use in a single shorthand property:
@@ -88,6 +88,11 @@ documented_functions:
       Becomes:
       
           background: url('/images/icons.png?12345678') 0 -24px no-repeat;
+
+      Passing `true` for `$use-percentages` results in the background position
+      being expressed in percentages instead of pixels. Example:
+        
+        background: url('/images/icons.png?12345678') 0 25% no-repeat;
 
 #sprite-width.helper
   %h3
@@ -149,7 +154,7 @@ documented_functions:
 #sprite-position.helper
   %h3
     %a(href="#sprite-position")
-      sprite-position(<span class="arg">$map</span>, <span class="arg">$sprite</span>, <span class="arg" data-default-value="0">$offset-x</span>, <span class="arg" data-default-value="0">$offset-y</span>)
+      sprite-position(<span class="arg">$map</span>, <span class="arg">$sprite</span>, <span class="arg" data-default-value="0">$offset-x</span>, <span class="arg" data-default-value="0">$offset-y</span>, <span class="arg" data-default-value="false">$use-percentages</span>)
   .details
     :markdown
       Returns the position for the original image in the sprite.
@@ -171,3 +176,14 @@ documented_functions:
       Would change the above output to:
       
           background-position: 3px -36px;
+
+      Passing `true` for the `$use-percentages` argument will return the
+      sprite position in percentages instead of pixels. This is useful if you
+      need to be able to scale the sprite up and down. Following the example
+      above, this:
+
+          background-position: sprite-position($icons, new, 0, 0, true);
+
+      Would result in something like:
+
+          background-position: 0 25%;

--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -11,8 +11,12 @@ $sprite-selectors: hover, target, active !default;
 // Set the background position of the given sprite `$map` to display the
 // sprite of the given `$sprite` name. You can move the image relative to its
 // natural position by passing `$offset-x` and `$offset-y`.
-@mixin sprite-background-position($map, $sprite, $offset-x: 0, $offset-y: 0) {
-  background-position: sprite-position($map, $sprite, $offset-x, $offset-y);  
+// The background-position will be returned in pixels. By passing `true
+// for `$use_percentages`, you get percentages instead.
+@mixin sprite-background-position($map, $sprite, $offset-x: 0, $offset-y: 0,
+$use-percentages: false) {
+  background-position: sprite-position($map, $sprite, $offset-x, $offset-y,
+  $use-percentages);
 }
 
 
@@ -24,25 +28,31 @@ $disable-magic-sprite-selectors:false !default;
 // class or you can specify the `sprite-url` explicitly like this:
 //
 //     background: $map no-repeat;
-@mixin sprite($map, $sprite, $dimensions: false, $offset-x: 0, $offset-y: 0) {
-  @include sprite-background-position($map, $sprite, $offset-x, $offset-y);
+@mixin sprite($map, $sprite, $dimensions: false, $offset-x: 0, $offset-y: 0,
+$use-percentages: false) {
+  @include sprite-background-position($map, $sprite, $offset-x, $offset-y,
+  $use-percentages);
   @if $dimensions {
     @include sprite-dimensions($map, $sprite);
   }
   @if not $disable-magic-sprite-selectors {
-    @include sprite-selectors($map, $sprite, $sprite, $offset-x, $offset-y);
+    @include sprite-selectors($map, $sprite, $sprite, $offset-x, $offset-y,
+    $use-percentages);
   }
 }
 
 // Include the selectors for the `$sprite` given the `$map` and the 
 // `$full-sprite-name`
 // @private
-@mixin sprite-selectors($map, $sprite-name, $full-sprite-name, $offset-x: 0, $offset-y: 0) {
+@mixin sprite-selectors($map, $sprite-name, $full-sprite-name, $offset-x: 0,
+$offset-y: 0, $use-percentages: false) {
   @each $selector in $sprite-selectors {
     @if sprite_has_selector($map, $sprite-name, $selector) {
       @if sprite_has_valid_selector("#{$full-sprite-name}-#{$selector}") {
         &:#{$selector}, &.#{$full-sprite-name}-#{$selector} {
-            @include sprite-background-position($map, "#{$sprite-name}_#{$selector}", $offset-x, $offset-y);
+            @include sprite-background-position($map,
+            "#{$sprite-name}_#{$selector}", $offset-x, $offset-y, 
+            $use-percentages);
         }
       }
     }
@@ -55,14 +65,19 @@ $disable-magic-sprite-selectors:false !default;
 // If a base class is provided, then each class will extend it.
 //
 // If `$dimensions` is `true`, the sprite dimensions will specified.
-@mixin sprites($map, $sprite-names, $base-class: false, $dimensions: false, $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0) {
+// Positions are returned in pixel units. Set `$use_percentages` to true to
+// instead get percentages.
+@mixin sprites($map, $sprite-names, $base-class: false, $dimensions: false,
+$prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0, $use-percentages:
+false) {
   @each $sprite-name in $sprite-names {
     @if sprite_does_not_have_parent($map, $sprite-name) {
       $full-sprite-name: "#{$prefix}-#{$sprite-name}";
       @if sprite_has_valid_selector($full-sprite-name) {
         .#{$full-sprite-name} {
           @if $base-class { @extend #{$base-class}; }
-          @include sprite($map, $sprite-name, $dimensions, $offset-x, $offset-y);
+          @include sprite($map, $sprite-name, $dimensions, $offset-x, $offset-y, 
+          $use-percentages);
         }
       }
     }

--- a/lib/compass/commands/update_project.rb
+++ b/lib/compass/commands/update_project.rb
@@ -9,7 +9,7 @@ module Compass
           Usage: compass compile [path/to/project] [path/to/project/src/file.sass ...] [options]
 
           Description:
-          compile project at the path specified or the current director if not specified.
+          compile project at the path specified or the current directory if not specified.
 
           Options:
         }.split("\n").map{|l| l.gsub(/^ */,'')}.join("\n")

--- a/lib/compass/sass_extensions/functions/sprites.rb
+++ b/lib/compass/sass_extensions/functions/sprites.rb
@@ -1,5 +1,6 @@
 module Compass::SassExtensions::Functions::Sprites
   ZERO = Sass::Script::Number::new(0)
+  BOOL_FALSE = Sass::Script::Bool::new(false)
   VALID_SELECTORS = %w(hover active target)
   # Provides a consistent interface for getting a variable in ruby
   # from a keyword argument hash that accounts for underscores/dash equivalence
@@ -76,17 +77,24 @@ module Compass::SassExtensions::Functions::Sprites
   # Becomes:
   #
   #     background: url('/images/icons.png?12345678') 0 -24px no-repeat;
-  def sprite(map, sprite, offset_x = ZERO, offset_y = ZERO)
-    sprite = convert_sprite_name(sprite)    
+  #
+  # If the `use_percentages` parameter is passed as true, percentages will be
+  # used to position the sprite. Example output:
+  #     
+  #     background: url('/images/icons.png?12345678') 0 50% no-repeat;
+  #
+  def sprite(map, sprite, offset_x = ZERO, offset_y = ZERO, use_percentages = BOOL_FALSE)
+    sprite = convert_sprite_name(sprite)
     verify_map(map)
     verify_sprite(sprite)
     url = sprite_url(map)
-    position = sprite_position(map, sprite, offset_x, offset_y)
+    position = sprite_position(map, sprite, offset_x, offset_y, use_percentages)
     Sass::Script::List.new([url] + position.value, :space)
   end
   Sass::Script::Functions.declare :sprite, [:map, :sprite]
   Sass::Script::Functions.declare :sprite, [:map, :sprite, :offset_x]
   Sass::Script::Functions.declare :sprite, [:map, :sprite, :offset_x, :offset_y]
+  Sass::Script::Functions.declare :sprite, [:map, :sprite, :offset_x, :offset_y, :use_percentages]
 
   # Returns the name of a sprite map
   # The name is derived from the folder than contains the sprites.
@@ -167,7 +175,17 @@ module Compass::SassExtensions::Functions::Sprites
   # Would change the above output to:
   #
   #     background-position: 3px -36px;
-  def sprite_position(map, sprite = nil, offset_x = ZERO, offset_y = ZERO)
+  #
+  # If you set the `use_percentages` parameter to true, the position will be
+  # expressed in percentages. An example:
+  #
+  #     background-position: sprite-position($icons, new, 0, 0, true);
+  #
+  # Would result in something like this:
+  #
+  #     background-position: 0 42%;
+  # 
+  def sprite_position(map, sprite = nil, offset_x = ZERO, offset_y = ZERO, use_percentages = BOOL_FALSE)
     assert_type offset_x, :Number
     assert_type offset_y, :Number
     sprite = convert_sprite_name(sprite)
@@ -179,20 +197,30 @@ module Compass::SassExtensions::Functions::Sprites
     unless image
       missing_image!(map, sprite)
     end
-    if offset_x.unit_str == "%"
-      x = offset_x # CE: Shouldn't this be a percentage of the total width?
+    if use_percentages.value
+      xdivis = map.width - image.width;
+      x = (offset_x.value + image.left.to_f) / (xdivis.nonzero? || 1) * 100
+      x = Sass::Script::Number.new(x, x == 0 ? [] : ["%"])
+      ydivis = map.height - image.height;
+      y = (offset_y.value + image.top.to_f) / (ydivis.nonzero? || 1) * 100
+      y = Sass::Script::Number.new(y, y == 0 ? [] : ["%"])
     else
-      x = offset_x.value - image.left
-      x = Sass::Script::Number.new(x, x == 0 ? [] : ["px"])
+      if offset_x.unit_str == "%"
+        x = offset_x # CE: Shouldn't this be a percentage of the total width?
+      else
+        x = offset_x.value - image.left
+        x = Sass::Script::Number.new(x, x == 0 ? [] : ["px"])
+      end
+      y = offset_y.value - image.top
+      y = Sass::Script::Number.new(y, y == 0 ? [] : ["px"])
     end
-    y = offset_y.value - image.top
-    y = Sass::Script::Number.new(y, y == 0 ? [] : ["px"])
     Sass::Script::List.new([x, y],:space)
   end
   Sass::Script::Functions.declare :sprite_position, [:map]
   Sass::Script::Functions.declare :sprite_position, [:map, :sprite]
   Sass::Script::Functions.declare :sprite_position, [:map, :sprite, :offset_x]
   Sass::Script::Functions.declare :sprite_position, [:map, :sprite, :offset_x, :offset_y]
+  Sass::Script::Functions.declare :sprite_position, [:map, :sprite, :offset_x, :offset_y, :use_percentages]
 
   def sprite_image(*args)
     raise Sass::SyntaxError, %Q(The sprite-image() function has been replaced by sprite(). See http://compass-style.org/help/tutorials/spriting/ for more information.)

--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -4,6 +4,7 @@
 // You can override them before you import this file.
 $<%= name %>-sprite-base-class : ".<%= name %>-sprite" !default;
 $<%= name %>-sprite-dimensions : false !default;
+$<%= name %>-use-percentages   : false !default;
 $<%= name %>-position          : 0% !default;
 $<%= name %>-spacing           : 0 !default;
 $<%= name %>-repeat            : no-repeat !default;
@@ -62,22 +63,22 @@ $<%= name %>-inline            : false !default;
 }
 
 // Move the background position to display the sprite.
-@mixin <%= name %>-sprite-position($name, $offset-x: 0, $offset-y: 0) {
-  @include sprite-background-position($<%= name %>-sprites, $name, $offset-x, $offset-y)
+@mixin <%= name %>-sprite-position($name, $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages) {
+  @include sprite-background-position($<%= name %>-sprites, $name, $offset-x, $offset-y, $use-percentages)
 }
 
 // Extends the sprite base class and set the background position for the desired sprite.
 // It will also apply the image dimensions if $dimensions is true.
-@mixin <%= name %>-sprite($name, $dimensions: $<%= name %>-sprite-dimensions, $offset-x: 0, $offset-y: 0) {
+@mixin <%= name %>-sprite($name, $dimensions: $<%= name %>-sprite-dimensions, $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages) {
   @extend #{$<%= name %>-sprite-base-class};
-  @include sprite($<%= name %>-sprites, $name, $dimensions, $offset-x, $offset-y)
+  @include sprite($<%= name %>-sprites, $name, $dimensions, $offset-x, $offset-y, $use-percentages);
 }
 
-@mixin <%= name %>-sprites($sprite-names, $dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0) {
-  @include sprites($<%= name %>-sprites, $sprite-names, $<%= name %>-sprite-base-class, $dimensions, $prefix, $offset-x, $offset-y)
+@mixin <%= name %>-sprites($sprite-names, $dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages) {
+  @include sprites($<%= name %>-sprites, $sprite-names, $<%= name %>-sprite-base-class, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages)
 }
 
 // Generates a class for each sprited image.
-@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0) {
-  @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y);
+@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages) {
+  @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages);
 }

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -475,6 +475,122 @@ class SpritesTest < Test::Unit::TestCase
     CSS
   end
  
+  it "should use percentage positions when use_percentages is true" do
+    css = render <<-SCSS
+      @import "squares/*.png";
+      $squares-use-percentages: true;
+      .foo {
+        @include squares-sprite-position("twenty-by-twenty");
+      }
+      .bar {
+        @include squares-sprite-position("ten-by-ten");
+        @include squares-sprite-dimensions("ten-by-ten");
+      }
+    SCSS
+    assert_correct css, <<-CSS
+      .squares-sprite {
+        background: url('/squares-sbbc18e2129.png') no-repeat;
+      }
+      
+      .foo {
+        background-position: 0 100%;
+      }
+      
+      .bar {
+        background-position: 0 0;
+        height: 10px;
+        width: 10px;
+      }
+    CSS
+  end
+  
+  it "should use correct percentages when use_percentages is with horizontal layout" do
+    css = render <<-SCSS
+      $squares-layout: horizontal;
+      @import "squares/*.png";
+      $squares-use-percentages: true;
+      .foo {
+        @include squares-sprite-position("twenty-by-twenty");
+      }
+      .bar {
+        @include squares-sprite-position("ten-by-ten");
+      }
+    SCSS
+    assert_correct css, <<-CSS
+      .squares-sprite {
+        background: url('/squares-s4bd95c5c56.png') no-repeat;
+      }
+      
+      .foo {
+        background-position: 100% 0;
+      }
+      
+      .bar {
+        background-position: 0 0;
+      }
+    CSS
+  end
+
+  it "should use correct percentages when use_percentages is true with smart layout" do
+    css = render <<-SCSS
+      $image_row-layout: smart;
+      @import "image_row/*.png";
+      $image_row-use-percentages: true;
+      .foo {
+        @include image_row-sprite-position("medium");
+      }
+      .bar {
+        @include image_row-sprite-position("large_square");
+      }
+    SCSS
+    assert_correct css, <<-CSS
+      .image_row-sprite {
+        background: url('/image_row-sc5082a6b9f.png') no-repeat;
+      }
+      
+      .foo {
+        background-position: 0 50%;
+      }
+      
+      .bar {
+        background-position: 33.33333% 100%;
+      }
+    CSS
+  end
+
+  it "should use correct percentages when use_percentages is true" do
+    css = render <<-SCSS
+      $image_row-use-percentages: true;
+      @import "image_row/*.png";
+      @include all-image_row-sprites;
+    SCSS
+    assert_correct css, <<-CSS
+      .image_row-sprite, .image_row-large, .image_row-large_square, .image_row-medium, .image_row-small, .image_row-tall {
+        background: url('/image_row-sdf383d45a3.png') no-repeat;
+      }
+      
+      .image_row-large {
+        background-position: 0 0;
+      }
+      
+      .image_row-large_square {
+        background-position: 0 40%;
+      }
+      
+      .image_row-medium {
+        background-position: 0 16.66667%;
+      }
+      
+      .image_row-small {
+        background-position: 0 100%;
+      }
+      
+      .image_row-tall {
+        background-position: 0 80%;
+      }
+    CSS
+  end
+  
   it "should calculate corret sprite demsions when givin spacing via issue#253" do
     css = render <<-SCSS
       $squares-spacing: 10px;


### PR DESCRIPTION
(This is a continuation of https://github.com/chriseppstein/compass/pull/1106, rebased onto master instead of stable.)

The default behaviour for sprites is to position the background image
with pixels. This works if the sprite itself will always be displayed in
its original pixel dimensions. However, as more and more websites turn
responsive, is is vital that we can scale images up and down (mostly
down).

This commit will add support for positioning the background image with
percentages instead of pixels. This will make it easier to scale a
sprite image up and down. You won't be able to do it out of the box
though, you still need to do some manual work:

Using "background-size: cover" instead of the default (auto)
Placing the sprite in a container with a specific width, then using the following magic to the sprite: height: 0; padding-top: 75%; //image height/width ratio width: 100%;
