### PR TITLE
Added 'text-transform:capitalize' to 'hide-text' mixin

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_replacement.scss
@@ -56,6 +56,8 @@ $hide-text-direction: left !default;
     white-space: nowrap;
     overflow: hidden;
   }
+  //Text transform capitalize fixes text-replacement issue when used in a <button> element on ie7
+  text-transform:capitalize;
 }
 
 // Hides text in an element by squishing the text into oblivion.


### PR DESCRIPTION
Added 'text-transform:capitalize' to the 'hide-text' mixin to fix issue with this text-replacement technique in IE7 on any <input> elements.

Here's a test case: http://jsbin.com/olikuj/1

Tested in ie7 with browserstack.
