### PR TITLE
Update lib/compass/sass_extensions/functions/math.rb

### DIFF
--- a/lib/compass/sass_extensions/functions/math.rb
+++ b/lib/compass/sass_extensions/functions/math.rb
@@ -23,7 +23,7 @@ module Compass::SassExtensions::Functions::Math
   def e()
     Sass::Script::Number.new(Math::E)
   end
-  Sass::Script::Functions.declare :pi, []
+  Sass::Script::Functions.declare :e, []
 
   def logarithm(number, base = e )
     assert_type number, :Number


### PR DESCRIPTION
`Sass::Script::Functions.declare :pi, []` was declared twice. I believe this should be declaring e, as it's right after e.
