### PR TITLE
Test JRuby and RBX in 18 and 19 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - jruby
-  - rbx
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
   - ree
 script: "bundle exec rake test features"


### PR DESCRIPTION
I've found issues running JRuby in 19 mode, which is now the default in 1.7
