### PR TITLE
Flush the stdout buffer after compiler runs

### DIFF
--- a/lib/compass/commands/watch_project.rb
+++ b/lib/compass/commands/watch_project.rb
@@ -143,8 +143,8 @@ module Compass
         if file = compiler.out_of_date?
           begin
             puts ">>> Change detected at "+Time.now.strftime("%T")+" to: #{relative || compiler.relative_stylesheet_name(file)}"
-            $stdout.flush
             compiler.run
+            $stdout.flush
             GC.start
           rescue StandardError => e
             ::Compass::Exec::Helpers.report_error(e, options)


### PR DESCRIPTION
Flush the stdout buffer after compiler runs to display all the standard outputs correctly when running in NodeJS spawn. Otherwise it outputs weird result:

When running "compass watch" by Node.js child_process.spawn like this :

``` javascript
var compass = require('child_process').spawn('compass', [ 'watch']);
compass.stdout.on('data', function (data) {
    console.log('' + data);
});
```

For the first time it only outputs : ">>> Change detected at 16:34:20 to: XXX", the expected followed lines are missing until another change is made. 
