### PR TITLE
Use image-url instead of stylesheet-url for ellipsis.xml

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/text/_ellipsis.scss
+++ b/frameworks/compass/stylesheets/compass/typography/text/_ellipsis.scss
@@ -20,6 +20,6 @@ $use-mozilla-ellipsis-binding: false !default;
     official
   );
   @if $experimental-support-for-mozilla and $use-mozilla-ellipsis-binding {
-    -moz-binding: stylesheet-url(unquote("xml/ellipsis.xml#ellipsis"));    
+    -moz-binding: image-url(unquote("xml/ellipsis.xml#ellipsis"));
   }
 }


### PR DESCRIPTION
This is because stylesheet-url automatically appends .css to the
end which makes the url look like:

xml/ellipsis.xml#ellipsis.css

when it should look like:

xml/ellipsis.xml#ellipsis
