### PR TITLE
Get travis passing on jruby 1.8 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - jruby
+  - jruby-18mode
+  - jruby-19mode
   - rbx
   - ree
 script: "bundle exec rake test features"

--- a/features/step_definitions/command_line_steps.rb
+++ b/features/step_definitions/command_line_steps.rb
@@ -256,7 +256,7 @@ end
 
 Then /^the image ([^ ]+) has a size of (\d+)x(\d+)$/ do |file, width, height| 
   # see http://snippets.dzone.com/posts/show/805
-  IO.read(file)[0x10..0x18].unpack('NN').should == [width.to_i, height.to_i]
+  open(file, "rb").read[0x10..0x18].unpack('NN').should == [width.to_i, height.to_i]
 end
 
 Then /^I should see the following lines of output:$/ do |table|

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -34,7 +34,7 @@ class SpritesTest < Test::Unit::TestCase
   end
 
   def image_size(file)
-    IO.read(map_location(file))[0x10..0x18].unpack('NN')
+    open(map_location(file), "rb").read[0x10..0x18].unpack('NN')
   end
 
   def image_md5(file)


### PR DESCRIPTION
Had to use open() instead of IO.read so that I could pass
the binary flag.
