### PR TITLE
Uses :filesystem_importer sass option, when provided, to create importers

### DIFF
--- a/lib/compass/compiler.rb
+++ b/lib/compass/compiler.rb
@@ -15,7 +15,8 @@ module Compass
       self.sass_options.delete(:quiet)
       self.sass_options.update(sass_opts)
       self.sass_options[:cache_location] ||= determine_cache_location
-      self.sass_options[:importer] = self.importer = Sass::Importers::Filesystem.new(from)
+      self.sass_options[:filesystem_importer] ||= Sass::Importers::Filesystem
+      self.sass_options[:importer] = self.importer = self.sass_options[:filesystem_importer].new(from)
       self.sass_options[:compass] ||= {}
       self.sass_options[:compass][:logger] = self.logger
       self.sass_options[:compass][:environment] = Compass.configuration.environment

--- a/lib/compass/configuration/adapters.rb
+++ b/lib/compass/configuration/adapters.rb
@@ -64,10 +64,12 @@ module Compass
         Compass::Frameworks::ALL.each do |f|
           load_paths << f.stylesheets_directory if File.directory?(f.stylesheets_directory)
         end
+        importer = sass_options[:filesystem_importer] if sass_options && sass_options[:filesystem_importer]
+        importer ||= Sass::Importers::Filesystem
         load_paths += resolve_additional_import_paths
         load_paths.map! do |p|
           next p if p.respond_to?(:find_relative)
-          Sass::Importers::Filesystem.new(p.to_s)
+          importer.new(p.to_s)
         end
         load_paths << Compass::SpriteImporter.new
         load_paths


### PR DESCRIPTION
Sass allows the user to overwrite the default importer using :filesystem_importer option. This makes Compass respect that option when used.

I didn't added any tests because, honestly, I don't think I could do a decent job without putting a LOT of effort to it, and this is a very small modification.

I'm starting a new OSS project called Liftr and I created a custom importer for sass which only imports a file once (https://gist.github.com/4549615) but I need to be able to set the `:filesystem_importer` option (supported by sass) for it to work. I think this import would actually be a nice addition to compass or even sass.
