### PR TITLE
added $spacing variable to sprite-map

### DIFF
--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -13,7 +13,7 @@ $<%= name %>-layout:vertical !default;
 $<%= name %>-inline: false !default;
 
 <% if skip_overrides %> 
-  $<%= name %>-sprites: sprite-map("<%= uri %>", $layout: $<%= name %>-layout, $cleanup: $<%= name %>-clean-up);
+  $<%= name %>-sprites: sprite-map("<%= uri %>", $layout: $<%= name %>-layout, $cleanup: $<%= name %>-clean-up, $spacing: $<%= name %>-spacing);
 <% else %>  
  // These variables control the generated sprite output
  // You can override them selectively before you import this file.


### PR DESCRIPTION
The $spacing variable was not being passed to the sprite-map function, so setting $name-spacing had no effect.
