### PR TITLE
require 'date' so Date#today is available for gemspec.date

### DIFF
--- a/compass.gemspec
+++ b/compass.gemspec
@@ -1,3 +1,4 @@
+require 'date'
 path = "#{File.dirname(__FILE__)}/lib"
 require File.join(path, 'compass/version')
 


### PR DESCRIPTION
I'm getting an undefined method `today' for Date:Class (NoMethodError) error in compass.gemspec when attempting to use compass master branch.  This fixes it
