### PR TITLE
Update Sass dependency to 3.2.5

### DIFF
--- a/compass.gemspec
+++ b/compass.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gemspec|
   gemspec.rubygems_version = "1.3.5"
   gemspec.summary = %q{A Real Stylesheet Framework}
 
-  gemspec.add_dependency 'sass', '~> 3.2.0.alpha.93'
+  gemspec.add_dependency 'sass', '~> 3.2.5'
   gemspec.add_dependency 'chunky_png', '~> 1.2'
   gemspec.add_dependency 'listen', '~> 0.5.3'
 


### PR DESCRIPTION
Sass 3.2.0.alpha.93 doesn't support variable arguments, so relying on Compass to install Sass results in syntax errors inside Compass, eg when importing [css3](https://github.com/chriseppstein/compass/blob/1724d70bd9c77aff31dc1c6e596e8b476fc7a656/frameworks/compass/stylesheets/compass/css3/_shared.scss#L220).
