### PR TITLE
Do not overwrite default legacy support.

### DIFF
--- a/frameworks/compass/stylesheets/compass/_support.scss
+++ b/frameworks/compass/stylesheets/compass/_support.scss
@@ -17,10 +17,10 @@ $legacy-support-for-ie8: $legacy-support-for-ie !default;
 $legacy-support-for-ie: $legacy-support-for-ie6 or $legacy-support-for-ie7 or $legacy-support-for-ie8;
 
 // Whether to output legacy support for mozilla.
-$legacy-support-for-mozilla: true;
+$legacy-support-for-mozilla: true !default;
 
 // Whether to output legacy support for webkit.
-$legacy-support-for-webkit: true;
+$legacy-support-for-webkit: true !default;
 
 // Support for mozilla in experimental css3 properties (-moz).
 $experimental-support-for-mozilla      : true !default;


### PR DESCRIPTION
Applies to mozilla and webkit.
