### PR TITLE
background-size doesn't need prefixes for opera or webkit

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_background-size.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_background-size.scss
@@ -22,5 +22,5 @@ $default-background-size: 100% auto !default;
 ) {
   $size-1: if(type-of($size-1) == string, unquote($size-1), $size-1);
   $sizes: compact($size-1, $size-2, $size-3, $size-4, $size-5, $size-6, $size-7, $size-8, $size-9, $size-10);
-  @include experimental(background-size, $sizes, -moz, -webkit, -o, not -ms, not -khtml);
+  @include experimental(background-size, $sizes, -moz, not -webkit, not -o, not -ms, not -khtml);
 }


### PR DESCRIPTION
background-size doesn't need prefixes for opera or webkit: http://www.standardista.com/css3/css3-background-properties
