### PR TITLE
Loosen `listen` gem dependency

### DIFF
--- a/compass.gemspec
+++ b/compass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gemspec|
 
   gemspec.add_dependency 'sass', '~> 3.2.5'
   gemspec.add_dependency 'chunky_png', '~> 1.2'
-  gemspec.add_dependency 'listen', ['>= 0.5.3', '>= 0.7.0']
+  gemspec.add_dependency 'listen', ['>= 0.5.3', '<= 0.7.0']
 
   gemspec.files = %w(README.markdown LICENSE.markdown VERSION.yml Rakefile)
   gemspec.files += Dir.glob("bin/*")

--- a/compass.gemspec
+++ b/compass.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gemspec|
 
   gemspec.add_dependency 'sass', '~> 3.2.5'
   gemspec.add_dependency 'chunky_png', '~> 1.2'
-  gemspec.add_dependency 'listen', '~> 0.5.3'
+  gemspec.add_dependency 'listen', ['>= 0.5.3', '>= 0.7.0']
 
   gemspec.files = %w(README.markdown LICENSE.markdown VERSION.yml Rakefile)
   gemspec.files += Dir.glob("bin/*")


### PR DESCRIPTION
See the commit message for details. Guard makes use of some new methods in the `listen` gem. In order to use both 1.6.x of `guard` and `compass` we need to loosen the dependencies a bit on versions.

Ended up just doing a range (it may work with latest listen gem `0.7.x` but did not want to mess testing every version and instead just fix the specific issue.

`gem.add_dependency 'listen', ['>= 0.5.3', '<= 0.7.0']` is what the line now looks like.
