### PR TITLE
Force should be explicitly stated in call.

### DIFF
--- a/lib/compass/commands/update_project.rb
+++ b/lib/compass/commands/update_project.rb
@@ -129,7 +129,6 @@ module Compass
             parser.options[:project_name] = arguments.shift if File.directory?(arguments.first)
             unless arguments.empty?
               parser.options[:sass_files] = arguments.dup
-              parser.options[:force] = true
             end
           end
         end


### PR DESCRIPTION
Automatically setting the force flag to true will cause all sprite maps generated by a compiling file to also be regenerated, even if they haven't been changed, in turn causing compilation to be overly slow. This was especially the case in third party programs that watch project directories on their own and call compass compile on individual files (instead of assuming `compass watch`).

Instead use `compass compile my_file.scss --force`.
