### PR TITLE
Stable

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_box.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_box.scss
@@ -1,6 +1,4 @@
-@import "compass/css3/shared";
-
-//@import "shared";
+@import "shared";
 
 // display:box; must be used for any of the other flexbox mixins to work properly
 @mixin display-box {

--- a/frameworks/compass/stylesheets/compass/css3/_box.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_box.scss
@@ -1,9 +1,11 @@
-@import "shared";
+@import "compass/css3/shared";
+
+//@import "shared";
 
 // display:box; must be used for any of the other flexbox mixins to work properly
 @mixin display-box {
   @include experimental-value(display, box,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -16,7 +18,7 @@ $default-box-orient: horizontal !default;
 ) {
   $orientation : unquote($orientation);
   @include experimental(box-orient, $orientation,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -29,7 +31,7 @@ $default-box-align: stretch !default;
 ) {
   $alignment : unquote($alignment);
   @include experimental(box-align, $alignment,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -43,7 +45,7 @@ $default-box-flex: 0 !default;
   $flex: $default-box-flex
 ) {
   @include experimental(box-flex, $flex,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -55,7 +57,7 @@ $default-box-flex-group: 1 !default;
   $group: $default-box-flex-group
 ) {
   @include experimental(box-flex-group, $group,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -67,7 +69,7 @@ $default-box-ordinal-group: 1 !default;
   $group: $default-ordinal-flex-group
 ) {
   @include experimental(box-ordinal-group, $group,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -80,7 +82,7 @@ $default-box-direction: normal !default;
 ) {
   $direction: unquote($direction);
   @include experimental(box-direction, $direction,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -93,7 +95,7 @@ $default-box-lines: single !default;
 ) {
   $lines: unquote($lines);
   @include experimental(box-lines, $lines,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }
 
@@ -106,6 +108,6 @@ $default-box-pack: start !default;
 ) {
   $pack: unquote($pack);
   @include experimental(box-pack, $pack,
-    -moz, -webkit, not -o, -ms, not -khtml, official
+    -moz, -webkit, not -o, not -ms, not -khtml, not official
   );
 }

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -1,0 +1,332 @@
+@import "compass/css3/shared";
+
+// NOTE:
+// All mixins for the 2009 spec have been written assuming they'll be fed property values that
+// correspond to the standard spec.  Some mixins can be fed values from the 2009 spec, but don't
+// rely on it.  The `legacy-order` mixin will increment the value fed to it because the 2009
+// `box-ordinal-group` property begins indexing at 1, while the modern `order` property begins
+// indexing at 0.
+
+// if `true`, the 2009 properties will be emitted as part of the normal mixin call
+// (if this is false, you're still free to explicitly call the legacy mixins yourself)
+$flex-legacy-enabled: false !default;
+
+// if `true`, properties are not emitted for browsers who don't support wrapping
+// (this includes suppressing the automatic emittion of 2009 properties)
+$flex-wrap-required : false !default;
+
+// September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
+// NOTE: FF does not support wrapping until version ??.  Because the `display: flex` property
+// is wrapped in a `@supports` block checking for `flex-wrap: wrap` (when $flex-wrap-required or
+// the $wrap argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when
+// support is added
+// Chrome 21 (prefixed)
+// Opera 12.1 (unprefixed)
+// Firefox 20 (unprefixed)
+$flex-webkit  : true  !default;
+$flex-moz     : false !default; // TODO: remove this?
+$flex-ms      : false !default;
+$flex-khtml   : false !default;
+$flex-official: true  !default;
+
+// March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
+// Chrome 17 (prefixed)
+// Internet Explorer 10 (prefixed)
+$flex-2012-webkit: true  !default;
+$flex-2012-ms    : true  !default;
+
+// July 2009 Working Draft (http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/)
+// NOTE: no browser that implements this spec is known to support `box-lines: multiple`
+// Chrome 4? (prefixed)
+// Safari 3.1 (prefixed)
+// Firefox <20 (prefixed)
+$flex-2009-webkit: true  !default;
+$flex-2009-moz   : true  !default;
+
+// ====================================================================================================
+//                                                                       | Common
+// ====================================================================================================
+
+// function for converting a value from the standard specification to one that is comparable from
+// an older specification
+@function flex-translate-value($value, $version: 2009) {
+	@if $value == flex {
+		@return if($version == 2009, box, flexbox);
+	} @else if $value == inline-flex {
+		@return if($version == 2009, inline-box, inline-flexbox);
+	} @else if $value == flex-start {
+		@return start;
+	} @else if $value == flex-end {
+		@return end;
+	} @else if $value == space-between {
+		@return justify;
+	} @else if $value == space-around { // 2009 doesn't have a value equivalent to `space-around`
+		@return if($version == 2009, justify, distribute);
+	}
+	@return $value;
+}
+
+@mixin flex-standard($property, $value) {
+	@include experimental($property, $value,
+		$flex-moz,
+		$flex-webkit,
+		false,
+		$flex-ms,
+		$flex-khtml,
+		$flex-official);
+}
+
+@mixin flex-2012($property, $value) {
+	@include experimental($property, $value,
+		false,
+		$flex-2012-webkit,
+		false,
+		$flex-2012-ms,
+		false,
+		false);
+}
+
+@mixin flex-2009($property, $value) {
+	@include experimental($property, $value,
+		$flex-2009-moz,
+		$flex-2009-webkit,
+		false,
+		false,
+		false,
+		false);
+}
+
+// mixin to use if standard and 2012 have the same property names
+@mixin flex-modern($property, $value) {
+	@include experimental($property, $value,
+		$flex-moz,
+		$flex-2012-webkit or $flex-webkit,
+		false, // opera
+		$flex-2012-ms or $flex-ms,
+		$flex-khtml,
+		$flex-official);
+}
+
+// ====================================================================================================
+//                                                                       | Display property
+// ====================================================================================================
+
+// $type: flex | inline-flex
+@mixin display-flex($type: flex, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-display-flex($type);
+	}
+	
+	@include experimental-value(display, flex-translate-value($type, 2012),
+		false,
+		$flex-2012-webkit,
+		false,
+		$flex-2012-ms,
+		false,
+		false);
+		
+	@include experimental-value(display, $type,
+		$flex-moz,
+		$flex-webkit,
+		false,
+		$flex-ms,
+		$flex-khtml,
+		$flex-official and not $wrap);
+	
+	@if $wrap {
+		@supports (flex-wrap: wrap) {
+			display: $type;
+		}
+	}
+}
+
+@mixin legacy-display-flex($type: flex) {
+	@include experimental-value(display, flex-translate-value($type, 2009),
+		$flex-2009-moz,
+		$flex-2009-webkit,
+		false,
+		false,
+		false,
+		false);
+}
+
+// ====================================================================================================
+//                                                                       | Flex-flow
+// ====================================================================================================
+
+// <'flex-direction'> || <'flex-wrap'>
+@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-flex-flow($value);
+	}
+	
+	@include flex-modern(flex-flow, $value);
+}
+
+@mixin legacy-flex-flow($value: row nowrap) {
+	@if length($value) > 1 { // 2009 version doesn't have a shorthand
+		@include legacy-flex-direction(nth($value, 1));
+		@include legacy-flex-wrap(nth($value, 2));
+	} @else {
+		@if $value == row or $value == row-reverse or $value == column or $value == column-reverse {
+			@include legacy-flex-direction($value);
+		} @else {
+			@include legacy-flex-wrap($value);
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+
+// $value: row | row-reverse | column | column-reverse
+@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-flex-direction($value);
+	}
+	
+	@include flex-modern(flex-direction, $value);
+}
+
+@mixin legacy-flex-direction($value: row) {
+	@include flex-2009(box-orient, if($value == row or $value == row-reverse, horizontal, vertical));
+	@include flex-2009(box-direction, if($value == row-reverse or $value == column-reverse, reverse, normal));
+}
+
+// ----------------------------------------------------------------------
+
+// $value: nowrap | wrap | wrap-reverse
+@mixin flex-wrap($value: nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-flex-wrap($value);
+	}
+	
+	@include flex-modern(flex-wrap, $value);
+}
+
+@mixin legacy-flex-wrap($value: nowrap) {
+	// NOTE: 2009 has no equivalent of wrap-reverse
+	@include flex-2009(box-lines, if($value == nowrap, single, multiple));
+}
+
+// ====================================================================================================
+//                                                                       | "Packing" & Alignment
+// ====================================================================================================
+
+// Distributing extra space along the "main axis"
+// $value: flex-start | flex-end | center | space-between | space-around
+@mixin justify-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-justify-content($value);
+	}
+	
+	@include flex-2012(flex-pack, flex-translate-value($value, 2012));
+	@include flex-standard(justify-content, $value);
+}
+
+@mixin legacy-justify-content($value: flex-start) {
+	@include flex-2009(box-pack, flex-translate-value($value, 2009));
+}
+
+// ----------------------------------------------------------------------
+
+// Distributing extra space along the "cross axis"
+// $value: flex-start | flex-end | center | space-between | space-around | stretch
+@mixin align-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-align-content($value);
+	}
+	
+	@include flex-2012(flex-line-pack, flex-translate-value($value, 2012));
+	@include flex-standard(align-content, $value);
+}
+
+@mixin legacy-align-content($value: flex-start) {
+	@include flex-2009(box-align, flex-translate-value($value, 2009));
+}
+
+// ----------------------------------------------------------------------
+
+// Align items along the "cross axis"
+// $value: flex-start | flex-end | center | baseline | stretch
+@mixin align-items($value: stretch) { // the flex container
+	// There is no 2009 version of this property
+	@include flex-2012(flex-align, flex-translate-value($value, 2012));
+	@include flex-standard(align-items, $value);
+}
+
+// ====================================================================================================
+//                                                                       | Flex (Child Property)
+// ====================================================================================================
+
+// $value: none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]
+@mixin flex($value: 0 1 auto, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and unitless(nth($value, 1)) {
+		// 2009 version does not have a shorthand, see `legacy-flex-grow`
+		@include legacy-flex-grow(nth($value, 1));
+	}
+	
+	@include flex-modern(flex, $value);
+}
+
+// ----------------------------------------------------------------------
+
+// $value: Integer
+@mixin flex-grow($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-flex-grow($value);
+	}
+	
+	// There is no 2012 version of this property
+	@include flex-standard(flex-grow, $value);
+}
+
+@mixin legacy-flex-grow($value: 0) {
+	@include flex-2009(box-flex, $value);
+}
+
+// ----------------------------------------------------------------------
+
+// $value: Integer
+@mixin flex-shrink($value: 1) {
+	// There is no 2009 version of this property
+	// There is no 2012 version of this property
+	@include flex-standard(flex-shrink, $value);
+}
+
+// ----------------------------------------------------------------------
+
+// $value: united number (eg: 100px)
+@mixin flex-basis($value: auto) {
+	// There is no 2009 version of this property
+	// There is no 2012 version of this property
+	@include flex-standard(flex-basis, $value);
+}
+
+// ====================================================================================================
+//                                                                       | Other Child properties
+// ====================================================================================================
+
+// Align items along the "cross axis" -- overrides `align-items` value on individual items
+// $value: auto | flex-start | flex-end | center | baseline | stretch
+@mixin align-self($value: auto) { // children of flex containers
+	// There is no 2009 version of this property
+	@include flex-2012(flex-item-align, flex-translate-value($value, 2012));
+	@include flex-standard(align-self, $value);
+}
+
+// ----------------------------------------------------------------------
+
+// $value: Integer
+@mixin order($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-order($value);
+	}
+	
+	@include flex-2012(flex-order, $value);
+	@include flex-standard(order, $value);
+}
+
+@mixin legacy-order($value: 0) {
+	// the 2009 spec starts the ordering at 1 instead of 0 like the modern specs
+	@include flex-2009(box-ordinal-group, $value + 1);
+}

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -48,6 +48,8 @@ $flex-2009-moz   : true  !default;
 // function for converting a value from the standard specification to one that is comparable from
 // an older specification
 @function flex-translate-value($value, $version: 2009) {
+	$value: unquote($value);
+
 	@if $value == flex {
 		@return if($version == 2009, box, flexbox);
 	} @else if $value == inline-flex {
@@ -65,6 +67,7 @@ $flex-2009-moz   : true  !default;
 }
 
 @mixin flex-standard($property, $value) {
+	$value: unquote($value);
 	@include experimental($property, $value,
 		not -moz,
 		$flex-webkit,
@@ -75,6 +78,7 @@ $flex-2009-moz   : true  !default;
 }
 
 @mixin flex-2012($property, $value) {
+	$value: unquote($value);
 	@include experimental($property, $value,
 		not -moz,
 		$flex-2012-webkit,
@@ -85,6 +89,7 @@ $flex-2009-moz   : true  !default;
 }
 
 @mixin flex-2009($property, $value) {
+	$value: unquote($value);
 	@include experimental($property, $value,
 		$flex-2009-moz,
 		$flex-2009-webkit,
@@ -96,6 +101,7 @@ $flex-2009-moz   : true  !default;
 
 // mixin to use if standard and 2012 have the same property names
 @mixin flex-modern($property, $value) {
+	$value: unquote($value);
 	@include experimental($property, $value,
 		not -moz,
 		$flex-2012-webkit or $flex-webkit,
@@ -166,6 +172,7 @@ $flex-2009-moz   : true  !default;
 		@include legacy-flex-direction(nth($value, 1));
 		@include legacy-flex-wrap(nth($value, 2));
 	} @else {
+		$value: unquote($value);
 		@if $value == row or $value == row-reverse or $value == column or $value == column-reverse {
 			@include legacy-flex-direction($value);
 		} @else {
@@ -186,6 +193,7 @@ $flex-2009-moz   : true  !default;
 }
 
 @mixin legacy-flex-direction($value: row) {
+	$value: unquote($value);
 	@include flex-2009(box-orient, if($value == row or $value == row-reverse, horizontal, vertical));
 	@include flex-2009(box-direction, if($value == row-reverse or $value == column-reverse, reverse, normal));
 }
@@ -258,6 +266,7 @@ $flex-2009-moz   : true  !default;
 
 // $value: none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]
 @mixin flex($value: 0 1 auto, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	$value: unquote($value);
 	@if $legacy and unitless(nth($value, 1)) {
 		// 2009 version does not have a shorthand, see `legacy-flex-grow`
 		@include legacy-flex-grow(nth($value, 1));

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -16,7 +16,7 @@ $flex-legacy-enabled: false !default;
 $flex-wrap-required : false !default;
 
 // September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
-// NOTE: FF does not support wrapping until version ??.  Because the `display: flex` property
+// NOTE: FF did not support wrapping until version ??.  Because the `display: flex` property
 // is wrapped in a `@supports` block checking for `flex-wrap: wrap` (when $flex-wrap-required or
 // the $wrap argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when
 // support is added
@@ -133,7 +133,7 @@ $flex-2009-moz   : true  !default;
 		$flex-khtml,
 		$flex-official and not $wrap);
 	
-	@if $wrap {
+	@if $wrap and $flex-official {
 		@supports (flex-wrap: wrap) {
 			display: $type;
 		}

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -17,9 +17,9 @@ $flex-wrap-required : false !default;
 
 // September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
 // NOTE: FF did not support wrapping until version ??.  Because the `display: flex` property
-// is wrapped in a `@supports` block checking for `flex-wrap: wrap` (when $flex-wrap-required or
-// the $wrap argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when
-// support is added
+// is wrapped in a `@supports (flex-wrap: wrap)` block (when $flex-wrap-required or the $wrap
+// argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when support is
+// finally added
 // Chrome 21 (prefixed)
 // Opera 12.1 (unprefixed)
 // Firefox 20 (unprefixed)
@@ -70,7 +70,7 @@ $flex-2009-moz   : true  !default;
 	@include experimental($property, $value,
 		$flex-moz,
 		$flex-webkit,
-		false,
+		not -o,
 		$flex-ms,
 		$flex-khtml,
 		$flex-official);
@@ -78,22 +78,22 @@ $flex-2009-moz   : true  !default;
 
 @mixin flex-2012($property, $value) {
 	@include experimental($property, $value,
-		false,
+		not -moz,
 		$flex-2012-webkit,
-		false,
+		not -o,
 		$flex-2012-ms,
-		false,
-		false);
+		not -khtml,
+		not -official);
 }
 
 @mixin flex-2009($property, $value) {
 	@include experimental($property, $value,
 		$flex-2009-moz,
 		$flex-2009-webkit,
-		false,
-		false,
-		false,
-		false);
+		not -o,
+		not -ms,
+		not -khtml,
+		not -official);
 }
 
 // mixin to use if standard and 2012 have the same property names
@@ -101,7 +101,7 @@ $flex-2009-moz   : true  !default;
 	@include experimental($property, $value,
 		$flex-moz,
 		$flex-2012-webkit or $flex-webkit,
-		false, // opera
+		not -o,
 		$flex-2012-ms or $flex-ms,
 		$flex-khtml,
 		$flex-official);
@@ -118,17 +118,17 @@ $flex-2009-moz   : true  !default;
 	}
 	
 	@include experimental-value(display, flex-translate-value($type, 2012),
-		false,
+		not -moz,
 		$flex-2012-webkit,
-		false,
+		not -o,
 		$flex-2012-ms,
-		false,
-		false);
+		not -khtml,
+		not -standard);
 		
 	@include experimental-value(display, $type,
 		$flex-moz,
 		$flex-webkit,
-		false,
+		not -o,
 		$flex-ms,
 		$flex-khtml,
 		$flex-official and not $wrap);
@@ -144,10 +144,10 @@ $flex-2009-moz   : true  !default;
 	@include experimental-value(display, flex-translate-value($type, 2009),
 		$flex-2009-moz,
 		$flex-2009-webkit,
-		false,
-		false,
-		false,
-		false);
+		not -o,
+		not -ms,
+		not -khtml,
+		not standard);
 }
 
 // ====================================================================================================

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -133,9 +133,15 @@ $flex-2009-moz   : true  !default;
 		$flex-khtml,
 		$flex-official and not $wrap);
 	
-	@if $wrap and $flex-official {
-		@supports (flex-wrap: wrap) {
-			display: $type;
+	@if $flex-official {
+		@if $wrap {
+			@supports (display: $type) and (flex-wrap: wrap) {
+				display: $type;
+			}
+		} @else {
+			@supports (display: $type) {
+				display: $type;
+			}
 		}
 	}
 }

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -11,7 +11,9 @@
 // (if this is false, you're still free to explicitly call the legacy mixins yourself)
 $flex-legacy-enabled: false !default;
 
-// if `true`, properties are not emitted for browsers who don't support wrapping
+// if `true`, `$flex-legacy-enabled` is treated as false and an `@supports` block is added to 
+// the display property to hide the standard value from versions of Firefox that support the
+// unprefixed properties, but do not support wrapping
 // (this includes suppressing the automatic emittion of 2009 properties)
 $flex-wrap-required : false !default;
 
@@ -112,7 +114,7 @@ $flex-2009-moz   : true  !default;
 }
 
 // ====================================================================================================
-//                                                                       | Display property
+//                                                                       | Display Property
 // ====================================================================================================
 
 // $type: flex | inline-flex
@@ -155,10 +157,10 @@ $flex-2009-moz   : true  !default;
 }
 
 // ====================================================================================================
-//                                                                       | Flex-flow
+//                                                                       | Flex Container Properties
 // ====================================================================================================
 
-// <'flex-direction'> || <'flex-wrap'>
+// $value: <'flex-direction'> || <'flex-wrap'>
 @mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	@if $legacy and not $wrap {
 		@include legacy-flex-flow($value);
@@ -214,9 +216,7 @@ $flex-2009-moz   : true  !default;
 	@include flex-2009(box-lines, if($value == nowrap, single, multiple));
 }
 
-// ====================================================================================================
-//                                                                       | "Packing" & Alignment
-// ====================================================================================================
+// ----------------------------------------------------------------------
 
 // Distributing extra space along the "main axis"
 // $value: flex-start | flex-end | center | space-between | space-around
@@ -261,7 +261,7 @@ $flex-2009-moz   : true  !default;
 }
 
 // ====================================================================================================
-//                                                                       | Flex (Child Property)
+//                                                                       | Flex Item Properties
 // ====================================================================================================
 
 // $value: none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]
@@ -309,9 +309,7 @@ $flex-2009-moz   : true  !default;
 	@include flex-standard(flex-basis, $value);
 }
 
-// ====================================================================================================
-//                                                                       | Other Child properties
-// ====================================================================================================
+// ----------------------------------------------------------------------
 
 // Align items along the "cross axis" -- overrides `align-items` value on individual items
 // $value: auto | flex-start | flex-end | center | baseline | stretch

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -24,9 +24,7 @@ $flex-wrap-required : false !default;
 // Opera 12.1 (unprefixed)
 // Firefox 20 (unprefixed)
 $flex-webkit  : true  !default;
-$flex-moz     : false !default; // TODO: remove this?
 $flex-ms      : false !default;
-$flex-khtml   : false !default;
 $flex-official: true  !default;
 
 // March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
@@ -68,11 +66,11 @@ $flex-2009-moz   : true  !default;
 
 @mixin flex-standard($property, $value) {
 	@include experimental($property, $value,
-		$flex-moz,
+		not -moz,
 		$flex-webkit,
 		not -o,
 		$flex-ms,
-		$flex-khtml,
+		not -khtml,
 		$flex-official);
 }
 
@@ -99,11 +97,11 @@ $flex-2009-moz   : true  !default;
 // mixin to use if standard and 2012 have the same property names
 @mixin flex-modern($property, $value) {
 	@include experimental($property, $value,
-		$flex-moz,
+		not -moz,
 		$flex-2012-webkit or $flex-webkit,
 		not -o,
 		$flex-2012-ms or $flex-ms,
-		$flex-khtml,
+		not -khtml,
 		$flex-official);
 }
 
@@ -126,11 +124,11 @@ $flex-2009-moz   : true  !default;
 		not -standard);
 		
 	@include experimental-value(display, $type,
-		$flex-moz,
+		not -moz,
 		$flex-webkit,
 		not -o,
 		$flex-ms,
-		$flex-khtml,
+		not -khtml,
 		$flex-official and not $wrap);
 	
 	@if $flex-official and $wrap {

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -1,4 +1,4 @@
-@import "compass/css3/shared";
+@import "shared";
 
 // NOTE:
 // All mixins for the 2009 spec have been written assuming they'll be fed property values that

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -133,15 +133,9 @@ $flex-2009-moz   : true  !default;
 		$flex-khtml,
 		$flex-official and not $wrap);
 	
-	@if $flex-official {
-		@if $wrap {
-			@supports (display: $type) and (flex-wrap: wrap) {
-				display: $type;
-			}
-		} @else {
-			@supports (display: $type) {
-				display: $type;
-			}
+	@if $flex-official and $wrap {
+		@supports (flex-wrap: wrap) {
+			display: $type;
 		}
 	}
 }

--- a/test/fixtures/stylesheets/compass/css/box.css
+++ b/test/fixtures/stylesheets/compass/css/box.css
@@ -1,103 +1,65 @@
 .hbox {
   display: -webkit-box;
   display: -moz-box;
-  display: -ms-box;
-  display: box;
   -webkit-box-orient: horizontal;
   -moz-box-orient: horizontal;
-  -ms-box-orient: horizontal;
-  box-orient: horizontal;
   -webkit-box-align: stretch;
-  -moz-box-align: stretch;
-  -ms-box-align: stretch;
-  box-align: stretch; }
+  -moz-box-align: stretch; }
   .hbox > * {
     -webkit-box-flex: 0;
-    -moz-box-flex: 0;
-    -ms-box-flex: 0;
-    box-flex: 0; }
+    -moz-box-flex: 0; }
 
 .vbox {
   display: -webkit-box;
   display: -moz-box;
-  display: -ms-box;
-  display: box;
   -webkit-box-orient: vertical;
   -moz-box-orient: vertical;
-  -ms-box-orient: vertical;
-  box-orient: vertical;
   -webkit-box-align: stretch;
-  -moz-box-align: stretch;
-  -ms-box-align: stretch;
-  box-align: stretch; }
+  -moz-box-align: stretch; }
   .vbox > * {
     -webkit-box-flex: 0;
-    -moz-box-flex: 0;
-    -ms-box-flex: 0;
-    box-flex: 0; }
+    -moz-box-flex: 0; }
 
 .spacer {
   -webkit-box-flex: 1;
-  -moz-box-flex: 1;
-  -ms-box-flex: 1;
-  box-flex: 1; }
+  -moz-box-flex: 1; }
 
 .reverse {
   -webkit-box-direction: reverse;
-  -moz-box-direction: reverse;
-  -ms-box-direction: reverse;
-  box-direction: reverse; }
+  -moz-box-direction: reverse; }
 
 .box-flex-0 {
   -webkit-box-flex: 0;
-  -moz-box-flex: 0;
-  -ms-box-flex: 0;
-  box-flex: 0; }
+  -moz-box-flex: 0; }
 
 .box-flex-1 {
   -webkit-box-flex: 1;
-  -moz-box-flex: 1;
-  -ms-box-flex: 1;
-  box-flex: 1; }
+  -moz-box-flex: 1; }
 
 .box-flex-2 {
   -webkit-box-flex: 2;
-  -moz-box-flex: 2;
-  -ms-box-flex: 2;
-  box-flex: 2; }
+  -moz-box-flex: 2; }
 
 .box-flex-group-0 {
   -webkit-box-flex-group: 0;
-  -moz-box-flex-group: 0;
-  -ms-box-flex-group: 0;
-  box-flex-group: 0; }
+  -moz-box-flex-group: 0; }
 
 .box-flex-group-1 {
   -webkit-box-flex-group: 1;
-  -moz-box-flex-group: 1;
-  -ms-box-flex-group: 1;
-  box-flex-group: 1; }
+  -moz-box-flex-group: 1; }
 
 .box-flex-group-2 {
   -webkit-box-flex-group: 2;
-  -moz-box-flex-group: 2;
-  -ms-box-flex-group: 2;
-  box-flex-group: 2; }
+  -moz-box-flex-group: 2; }
 
 .start {
   -webkit-box-pack: start;
-  -moz-box-pack: start;
-  -ms-box-pack: start;
-  box-pack: start; }
+  -moz-box-pack: start; }
 
 .end {
   -webkit-box-pack: end;
-  -moz-box-pack: end;
-  -ms-box-pack: end;
-  box-pack: end; }
+  -moz-box-pack: end; }
 
 .center {
   -webkit-box-pack: center;
-  -moz-box-pack: center;
-  -ms-box-pack: center;
-  box-pack: center; }
+  -moz-box-pack: center; }

--- a/test/fixtures/stylesheets/compass/css/flexbox.css
+++ b/test/fixtures/stylesheets/compass/css/flexbox.css
@@ -1,0 +1,121 @@
+.flex {
+  display: -webkit-flexbox;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-flow: column nowrap;
+  -ms-flex-flow: column nowrap;
+  flex-flow: column nowrap;
+  -webkit-flex-pack: justify;
+  -ms-flex-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-flex-line-pack: center;
+  -ms-flex-line-pack: center;
+  -webkit-align-content: center;
+  align-content: center;
+  -webkit-flex-align: end;
+  -ms-flex-align: end;
+  -webkit-align-items: flex-end;
+  align-items: flex-end; }
+
+.flex-item {
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-flex-item-align: start;
+  -ms-flex-item-align: start;
+  -webkit-align-self: flex-start;
+  align-self: flex-start;
+  -webkit-flex-order: 2;
+  -ms-flex-order: 2;
+  -webkit-order: 2;
+  order: 2; }
+
+.flex-legacy {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -webkit-flexbox;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-box-orient: horizontal;
+  -moz-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -moz-box-direction: normal;
+  -webkit-box-lines: single;
+  -moz-box-lines: single;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: end;
+  -moz-box-pack: end;
+  -webkit-flex-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-box-align: start;
+  -moz-box-align: start;
+  -webkit-flex-line-pack: start;
+  -ms-flex-line-pack: start;
+  -webkit-align-content: flex-start;
+  align-content: flex-start;
+  -webkit-flex-align: baseline;
+  -ms-flex-align: baseline;
+  -webkit-align-items: baseline;
+  align-items: baseline; }
+
+.flex-item-legacy {
+  -webkit-box-flex: 2;
+  -moz-box-flex: 2;
+  -webkit-flex: 2 1 20em;
+  -ms-flex: 2 1 20em;
+  flex: 2 1 20em;
+  -webkit-flex-item-align: stretch;
+  -ms-flex-item-align: stretch;
+  -webkit-align-self: stretch;
+  align-self: stretch;
+  -webkit-box-ordinal-group: 4;
+  -moz-box-ordinal-group: 4;
+  -webkit-flex-order: 3;
+  -ms-flex-order: 3;
+  -webkit-order: 3;
+  order: 3; }
+
+.flex-legacy {
+  display: -webkit-flexbox;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+  -webkit-flex-pack: distribute;
+  -ms-flex-pack: distribute;
+  -webkit-justify-content: space-around;
+  justify-content: space-around;
+  -webkit-flex-line-pack: stretch;
+  -ms-flex-line-pack: stretch;
+  -webkit-align-content: stretch;
+  align-content: stretch;
+  -webkit-flex-align: start;
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  align-items: flex-start; }
+  @supports (flex-wrap: wrap) {
+    .flex-legacy {
+      display: flex; } }
+
+.flex-item-legacy {
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  -webkit-flex: 1 2 50%;
+  -ms-flex: 1 2 50%;
+  flex: 1 2 50%;
+  -webkit-flex-item-align: start;
+  -ms-flex-item-align: start;
+  -webkit-align-self: flex-start;
+  align-self: flex-start;
+  -webkit-flex-order: 1;
+  -ms-flex-order: 1;
+  -webkit-order: 1;
+  order: 1; }

--- a/test/fixtures/stylesheets/compass/sass/flexbox.scss
+++ b/test/fixtures/stylesheets/compass/sass/flexbox.scss
@@ -1,3 +1,5 @@
+@import "compass/css3/flexbox";
+
 .flex {
 	@include display-flex;
 	@include flex-flow(column nowrap);

--- a/test/fixtures/stylesheets/compass/sass/flexbox.scss
+++ b/test/fixtures/stylesheets/compass/sass/flexbox.scss
@@ -1,0 +1,42 @@
+.flex {
+	@include display-flex;
+	@include flex-flow(column nowrap);
+	@include justify-content(space-between);
+	@include align-content(center);
+	@include align-items(flex-end);
+}
+
+.flex-item {
+	@include flex(1 1 auto);
+	@include align-self(flex-start);
+	@include order(2);
+}
+
+$flex-legacy-enabled: true;
+.flex-legacy {
+	@include display-flex;
+	@include flex-flow(row nowrap);
+	@include justify-content(flex-end);
+	@include align-content(flex-start);
+	@include align-items(baseline);
+}
+
+.flex-item-legacy {
+	@include flex(2 1 20em);
+	@include align-self(stretch);
+	@include order(3);
+}
+$flex-wrap-required: true;
+.flex-legacy {
+	@include display-flex;
+	@include flex-flow(row wrap);
+	@include justify-content(space-around);
+	@include align-content(stretch);
+	@include align-items(flex-start);
+}
+
+.flex-item-legacy {
+	@include flex(1 2 50%);
+	@include align-self(flex-start);
+	@include order(1);
+}


### PR DESCRIPTION
Added new mixins for Flexbox as referenced from https://github.com/chriseppstein/compass/issues/921.  Left out the typical `$default-property-name` style variables because I worry about a potential naming conflict regarding the `$default-order` variable to go with the `order` mixin.

Added test for new mixin collection (I hope I've done this right)

Removed -ms- and standard prefixes from the old box collection.  IE10 doesn't use the draft these properties come from.

Updated test for old box collection
