### PR TITLE
Transitions WIP

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_transition.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transition.scss
@@ -1,19 +1,11 @@
+// CSS Transitions
+
 @import "shared";
 
-// CSS Transitions
-// Currently only works in Webkit.
-//
-// * expected in CSS3, FireFox 3.6/7 and Opera Presto 2.3
-// * We'll be prepared.
-//
-// Including this submodule sets following defaults for the mixins:
-//
-//     $default-transition-property : all
-//     $default-transition-duration : 1s
-//     $default-transition-function : false
-//     $default-transition-delay    : false
-//
-// Override them if you like. Timing-function and delay are set to false for browser defaults (ease, 0s).
+// @private css3-feature-support variables must always include a list of five boolean values
+// representing in order: -moz, -webkit, -ms, -o, -khtml.
+$transition-support: not -moz, -webkit, not -ms, not -o, not -khtml;
+
 
 $default-transition-property: all !default;
 
@@ -23,53 +15,32 @@ $default-transition-function: false !default;
 
 $default-transition-delay: false !default;
 
-$transitionable-prefixed-values: transform, transform-origin !default;
+// These values need to be singled out, and have the given prefixes added to them.
+$transitionable-prefixed-values : transform ms webkit,
+                                  transform-origin ms webkit,
+                                  box-shadow webkit
+                                  !default;
 
 // One or more properties to transition
 //
 // * for multiple, use a comma-delimited list
 // * also accepts "all" or "none"
-
-@mixin transition-property($property-1: $default-transition-property,
-  $property-2 : false,
-  $property-3 : false,
-  $property-4 : false,
-  $property-5 : false,
-  $property-6 : false,
-  $property-7 : false,
-  $property-8 : false,
-  $property-9 : false,
-  $property-10: false
+@mixin transition-property(
+  $property...
 ) {
-  @if type-of($property-1) == string { $property-1: unquote($property-1); }
-  $properties: compact($property-1, $property-2, $property-3, $property-4, $property-5, $property-6, $property-7, $property-8, $property-9, $property-10);
-  @if $experimental-support-for-webkit    {       -webkit-transition-property : prefixed-for-transition(-webkit, $properties); }
-  @if $experimental-support-for-mozilla   {          -moz-transition-property : prefixed-for-transition(-moz,    $properties); }
-  @if $experimental-support-for-opera     {            -o-transition-property : prefixed-for-transition(-o,      $properties); }
-                                                          transition-property : $properties;
+  $properties: set-arglist-default($property, $default-transition-property);
+  @include experimental(transition-property, $properties, $transition-support...);
 }
 
 // One or more durations in seconds
 //
 // * for multiple, use a comma-delimited list
 // * these durations will affect the properties in the same list position
-
-@mixin transition-duration($duration-1: $default-transition-duration,
-  $duration-2 : false,
-  $duration-3 : false,
-  $duration-4 : false,
-  $duration-5 : false,
-  $duration-6 : false,
-  $duration-7 : false,
-  $duration-8 : false,
-  $duration-9 : false,
-  $duration-10: false
+@mixin transition-duration(
+  $duration...
 ) {
-  @if type-of($duration-1) == string { $duration-1: unquote($duration-1); }
-  $durations: compact($duration-1, $duration-2, $duration-3, $duration-4, $duration-5, $duration-6, $duration-7, $duration-8, $duration-9, $duration-10);
-  @include experimental(transition-duration, $durations,
-    -moz, -webkit, not -ms, -o, not -khtml, official
-  );
+  $durations: set-arglist-default($duration, $default-transition-duration);
+  @include experimental(transition-duration, $durations, $transition-support...);
 }
 
 // One or more timing functions
@@ -77,50 +48,33 @@ $transitionable-prefixed-values: transform, transform-origin !default;
 // * [ ease | linear | ease-in | ease-out | ease-in-out | cubic-bezier(x1, y1, x2, y2)]
 // * For multiple, use a comma-delimited list
 // * These functions will effect the properties in the same list position
-
-@mixin transition-timing-function($function-1: $default-transition-function,
-  $function-2 : false,
-  $function-3 : false,
-  $function-4 : false,
-  $function-5 : false,
-  $function-6 : false,
-  $function-7 : false,
-  $function-8 : false,
-  $function-9 : false,
-  $function-10: false
+@mixin transition-timing-function(
+  $function...
 ) {
-  $function-1: unquote($function-1);
-  $functions: compact($function-1, $function-2, $function-3, $function-4, $function-5, $function-6, $function-7, $function-8, $function-9, $function-10);
-  @include experimental(transition-timing-function, $functions,
-    -moz, -webkit, not -ms, -o, not -khtml, official
-  );
+  $functions: set-arglist-default($function, $default-transition-function);
+  @include experimental(transition-timing-function, $functions, $transition-support...);
 }
 
 // One or more transition-delays in seconds
 //
 // * for multiple, use a comma-delimited list
 // * these delays will effect the properties in the same list position
-
-@mixin transition-delay($delay-1: $default-transition-delay,
-  $delay-2 : false,
-  $delay-3 : false,
-  $delay-4 : false,
-  $delay-5 : false,
-  $delay-6 : false,
-  $delay-7 : false,
-  $delay-8 : false,
-  $delay-9 : false,
-  $delay-10: false
+@mixin transition-delay(
+  $delay...
 ) {
-  @if type-of($delay-1) == string { $delay-1: unquote($delay-1); }
-  $delays: compact($delay-1, $delay-2, $delay-3, $delay-4, $delay-5, $delay-6, $delay-7, $delay-8, $delay-9, $delay-10);
-  @include experimental(transition-delay, $delays,
-    -moz, -webkit, not -ms, -o, not -khtml, official
-  );
+  $delays: set-arglist-default($delay, $default-transition-delay);
+  @include experimental(transition-delay, $delays, $transition-support...);
 }
 
 // Transition all-in-one shorthand
+@mixin transition(
+  $transition...
+) {
+  $transitions: set-arglist-default($transition, $default-transition-property $default-transition-duration $default-transition-function $default-transition-delay);
+  @include experimental(transition, $transitions, $transition-support...);
+}
 
+// Single Transition all-in-one
 @mixin single-transition(
   $property: $default-transition-property,
   $duration: $default-transition-duration,
@@ -128,94 +82,4 @@ $transitionable-prefixed-values: transform, transform-origin !default;
   $delay: $default-transition-delay
 ) {
   @include transition(compact($property $duration $function $delay));
-}
-
-@mixin transition(
-  $transition-1 : default,
-  $transition-2 : false,
-  $transition-3 : false,
-  $transition-4 : false,
-  $transition-5 : false,
-  $transition-6 : false,
-  $transition-7 : false,
-  $transition-8 : false,
-  $transition-9 : false,
-  $transition-10: false
-) {
-  @if $transition-1 == default {
-    $transition-1 : compact($default-transition-property $default-transition-duration $default-transition-function $default-transition-delay);
-  }
-  $transitions: false;
-  @if type-of($transition-1) == list and type-of(nth($transition-1,1)) == list {
-    $transitions: join($transition-1, compact($transition-2, $transition-3, $transition-4, $transition-5, $transition-6, $transition-7, $transition-8, $transition-9, $transition-10), comma);
-  } @else {
-    $transitions : compact($transition-1, $transition-2, $transition-3, $transition-4, $transition-5, $transition-6, $transition-7, $transition-8, $transition-9, $transition-10);
-  }
-  $delays: comma-list();
-  $has-delays: false;
-  $webkit-value: comma-list();
-  $moz-value: comma-list();
-  $o-value: comma-list();
-
-  // This block can be made considerably simpler at the point in time that
-  // we no longer need to deal with the differences in how delays are treated.
-  @each $transition in $transitions {
-    // Extract the values from the list
-    // (this would be cleaner if nth took a 3rd argument to provide a default value).
-    $property: nth($transition, 1);
-    $duration: false;
-    $timing-function: false;
-    $delay: false;
-    @if length($transition) > 1 { $duration:        nth($transition, 2); }
-    @if length($transition) > 2 { $timing-function: nth($transition, 3); }
-    @if length($transition) > 3 { $delay:           nth($transition, 4); $has-delays: true; }
-
-    // If a delay is provided without a timing function
-    @if is-time($timing-function) and not $delay { $delay: $timing-function; $timing-function: false; $has-delays: true; }
-
-    // Keep a list of delays in case one is specified
-    $delays: append($delays, if($delay, $delay, 0s));
-
-    $webkit-value: append($webkit-value, compact(prefixed-for-transition(-webkit, $property) $duration $timing-function));
-       $moz-value: append(   $moz-value, compact(prefixed-for-transition(   -moz, $property) $duration $timing-function $delay));
-         $o-value: append(     $o-value, compact(prefixed-for-transition(     -o, $property) $duration $timing-function $delay));
-  }
-
-  @if $experimental-support-for-webkit    {       -webkit-transition : $webkit-value;
-    // old webkit doesn't support the delay parameter in the shorthand so we progressively enhance it.
-    @if $has-delays                       { -webkit-transition-delay : $delays;       } }
-  @if $experimental-support-for-mozilla   {          -moz-transition : $moz-value;    }
-  @if $experimental-support-for-opera     {            -o-transition : $o-value;      }
-                                                          transition : $transitions;
-}
-
-// coerce a list to be comma delimited or make a new, empty comma delimited list.
-@function comma-list($list: ()) {
-  @return join((), $list, comma);
-}
-
-// Returns `$property` with the given prefix if it is found in `$transitionable-prefixed-values`.
-@function prefixed-for-transition($prefix, $property) {
-  @if type-of($property) == list {
-    $new-list: comma-list();
-    @each $v in $property {
-      $new-list: append($new-list, prefixed-for-transition($prefix, $v));
-    }
-    @return $new-list;
-  } @else {
-    @if index($transitionable-prefixed-values, $property) {
-      @return #{$prefix}-#{$property};
-    } @else {
-      @return $property;
-    }
-  }
-}
-
-// Checks if the value given is a unit of time.
-@function is-time($value) {
-  @if type-of($value) == number {
-    @return not not index(s ms, unit($value));
-  } @else {
-    @return false;
-  }
 }

--- a/frameworks/compass/stylesheets/compass/css3/_transition.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transition.scss
@@ -11,9 +11,9 @@ $default-transition-property: all !default;
 
 $default-transition-duration: 1s !default;
 
-$default-transition-function: false !default;
+$default-transition-function: null !default;
 
-$default-transition-delay: false !default;
+$default-transition-delay: null !default;
 
 // These values need to be singled out, and have the given prefixes added to them.
 $transitionable-prefixed-values : transform ms webkit,
@@ -70,7 +70,7 @@ $transitionable-prefixed-values : transform ms webkit,
 @mixin transition(
   $transition...
 ) {
-  $transitions: set-arglist-default($transition, $default-transition-property $default-transition-duration $default-transition-function $default-transition-delay);
+  $transitions: set-arglist-default($transition, compact($default-transition-property $default-transition-duration $default-transition-function $default-transition-delay));
   @include experimental(transition, $transitions, $transition-support...);
 }
 

--- a/test/fixtures/stylesheets/compass/css/transition.css
+++ b/test/fixtures/stylesheets/compass/css/transition.css
@@ -50,8 +50,8 @@
   transition-property: opacity, transform, left; }
 
 .default-transition {
-  -webkit-transition: all 1s false false;
-  transition: all 1s false false; }
+  -webkit-transition: all 1s;
+  transition: all 1s; }
 
 .transition-timing {
   -webkit-transition-timing-function: ease-in;

--- a/test/fixtures/stylesheets/compass/css/transition.css
+++ b/test/fixtures/stylesheets/compass/css/transition.css
@@ -1,134 +1,82 @@
 .single-transition-without-delay {
   -webkit-transition: all 0.6s ease-out;
-  -moz-transition: all 0.6s ease-out;
-  -o-transition: all 0.6s ease-out;
   transition: all 0.6s ease-out; }
 
 .single-transition-with-delay {
-  -webkit-transition: all 0.6s ease-out;
-  -webkit-transition-delay: 0.2s;
-  -moz-transition: all 0.6s ease-out 0.2s;
-  -o-transition: all 0.6s ease-out 0.2s;
+  -webkit-transition: all 0.6s ease-out 0.2s;
   transition: all 0.6s ease-out 0.2s; }
-
-.transition-duration-string {
-  -webkit-transition-duration: 0.2s, 0.5s, 0.2s;
-  -moz-transition-duration: 0.2s, 0.5s, 0.2s;
-  -o-transition-duration: 0.2s, 0.5s, 0.2s;
-  transition-duration: 0.2s, 0.5s, 0.2s; }
 
 .transition-duration-list {
   -webkit-transition-duration: 0.2s, 0.5s, 0.2s;
-  -moz-transition-duration: 0.2s, 0.5s, 0.2s;
-  -o-transition-duration: 0.2s, 0.5s, 0.2s;
   transition-duration: 0.2s, 0.5s, 0.2s; }
 
 .multiple-transition-durations {
   -webkit-transition-duration: 0.2s, 0.5s, 0.2s;
-  -moz-transition-duration: 0.2s, 0.5s, 0.2s;
-  -o-transition-duration: 0.2s, 0.5s, 0.2s;
   transition-duration: 0.2s, 0.5s, 0.2s; }
 
 .single-transform-transition-without-delay {
   -webkit-transition: -webkit-transform 0.6s ease-out;
-  -moz-transition: -moz-transform 0.6s ease-out;
-  -o-transition: -o-transform 0.6s ease-out;
+  transition: -ms-transform 0.6s ease-out;
   transition: transform 0.6s ease-out; }
 
 .single-transform-transition-with-delay {
-  -webkit-transition: -webkit-transform 0.6s ease-out;
-  -webkit-transition-delay: 0.2s;
-  -moz-transition: -moz-transform 0.6s ease-out 0.2s;
-  -o-transition: -o-transform 0.6s ease-out 0.2s;
+  -webkit-transition: -webkit-transform 0.6s ease-out 0.2s;
+  transition: -ms-transform 0.6s ease-out 0.2s;
   transition: transform 0.6s ease-out 0.2s; }
 
 .transform-transition {
   -webkit-transition: -webkit-transform 0.6s ease-out;
-  -moz-transition: -moz-transform 0.6s ease-out;
-  -o-transition: -o-transform 0.6s ease-out;
+  transition: -ms-transform 0.6s ease-out;
   transition: transform 0.6s ease-out; }
 
 .multiple-transitions {
   -webkit-transition: -webkit-transform 0.6s ease-out, opacity 0.2s ease-in;
-  -moz-transition: -moz-transform 0.6s ease-out, opacity 0.2s ease-in;
-  -o-transition: -o-transform 0.6s ease-out, opacity 0.2s ease-in;
+  transition: -ms-transform 0.6s ease-out, opacity 0.2s ease-in;
   transition: transform 0.6s ease-out, opacity 0.2s ease-in; }
 
 .transition-property {
   -webkit-transition-property: -webkit-transform;
-  -moz-transition-property: -moz-transform;
-  -o-transition-property: -o-transform;
+  transition-property: -ms-transform;
   transition-property: transform; }
 
 .transition-properties {
   -webkit-transition-property: -webkit-transform, opacity, width, height, left, top;
-  -moz-transition-property: -moz-transform, opacity, width, height, left, top;
-  -o-transition-property: -o-transform, opacity, width, height, left, top;
+  transition-property: -ms-transform, opacity, width, height, left, top;
   transition-property: transform, opacity, width, height, left, top; }
 
 .multiple-transition-properties {
   -webkit-transition-property: opacity, -webkit-transform, left;
-  -moz-transition-property: opacity, -moz-transform, left;
-  -o-transition-property: opacity, -o-transform, left;
+  transition-property: opacity, -ms-transform, left;
   transition-property: opacity, transform, left; }
 
 .default-transition {
-  -webkit-transition: all 1s;
-  -moz-transition: all 1s;
-  -o-transition: all 1s;
-  transition: all 1s; }
+  -webkit-transition: all 1s false false;
+  transition: all 1s false false; }
 
 .transition-timing {
   -webkit-transition-timing-function: ease-in;
-  -moz-transition-timing-function: ease-in;
-  -o-transition-timing-function: ease-in;
   transition-timing-function: ease-in; }
 
 .transition-timings {
   -webkit-transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0);
-  -moz-transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0);
-  -o-transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0);
   transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0); }
 
 .transition-timings-list {
   -webkit-transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0);
-  -moz-transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0);
-  -o-transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0);
   transition-timing-function: ease-in, cubic-bezier(1, 0, 1, 0); }
-
-.transition-timings-string {
-  -webkit-transition-timing-function: ease-in, cubic-bezier(1,0,1,0);
-  -moz-transition-timing-function: ease-in, cubic-bezier(1,0,1,0);
-  -o-transition-timing-function: ease-in, cubic-bezier(1,0,1,0);
-  transition-timing-function: ease-in, cubic-bezier(1,0,1,0); }
 
 .transition-delay {
   -webkit-transition-delay: 1s;
-  -moz-transition-delay: 1s;
-  -o-transition-delay: 1s;
   transition-delay: 1s; }
 
 .transition-delays {
   -webkit-transition-delay: 1s, 2s, 3s;
-  -moz-transition-delay: 1s, 2s, 3s;
-  -o-transition-delay: 1s, 2s, 3s;
   transition-delay: 1s, 2s, 3s; }
 
 .transition-delays-list {
   -webkit-transition-delay: 1s, 2s, 3s;
-  -moz-transition-delay: 1s, 2s, 3s;
-  -o-transition-delay: 1s, 2s, 3s;
-  transition-delay: 1s, 2s, 3s; }
-
-.transition-delays-string {
-  -webkit-transition-delay: 1s, 2s, 3s;
-  -moz-transition-delay: 1s, 2s, 3s;
-  -o-transition-delay: 1s, 2s, 3s;
   transition-delay: 1s, 2s, 3s; }
 
 .regression-912 {
-  -webkit-transition: background-color 0.5s ease-in, width 0.5s ease-out, height 0.5s ease-in, top 0.5s ease-out;
-  -webkit-transition-delay: 0s, 0s, 0s, 0s;
-  -moz-transition: background-color 0.5s ease-in 0s, width 0.5s ease-out 0s, height 0.5s ease-in 0s, top 0.5s ease-out 0s;
-  -o-transition: background-color 0.5s ease-in 0s, width 0.5s ease-out 0s, height 0.5s ease-in 0s, top 0.5s ease-out 0s;
+  -webkit-transition: background-color 0.5s ease-in 0s, width 0.5s ease-out 0s, height 0.5s ease-in 0s, top 0.5s ease-out 0s;
   transition: background-color 0.5s ease-in 0s, width 0.5s ease-out 0s, height 0.5s ease-in 0s, top 0.5s ease-out 0s; }

--- a/test/fixtures/stylesheets/compass/sass/transition.scss
+++ b/test/fixtures/stylesheets/compass/sass/transition.scss
@@ -2,7 +2,6 @@
 
 .single-transition-without-delay  { @include single-transition(all, 0.6s, ease-out); }
 .single-transition-with-delay     { @include single-transition(all, 0.6s, ease-out, 0.2s); }
-.transition-duration-string { @include transition-duration("0.2s, 0.5s, 0.2s"); }
 .transition-duration-list { @include transition-duration((0.2s, 0.5s, 0.2s)); }
 .multiple-transition-durations { @include transition-duration(0.2s, 0.5s, 0.2s); }
 .single-transform-transition-without-delay  { @include single-transition(transform, 0.6s, ease-out); }
@@ -16,9 +15,7 @@
 .transition-timing { @include transition-timing-function(ease-in); }
 .transition-timings { @include transition-timing-function(ease-in, cubic-bezier(1,0,1,0)); }
 .transition-timings-list { @include transition-timing-function((ease-in, cubic-bezier(1,0,1,0))); }
-.transition-timings-string { @include transition-timing-function("ease-in, cubic-bezier(1,0,1,0)"); }
 .transition-delay { @include transition-delay(1s); }
 .transition-delays { @include transition-delay(1s, 2s, 3s); }
 .transition-delays-list { @include transition-delay((1s, 2s, 3s)); }
-.transition-delays-string { @include transition-delay("1s, 2s, 3s"); }
 .regression-912 { @include transition((background-color 0.5s ease-in 0s, width 0.5s ease-out 0s, height 0.5s ease-in 0s, top 0.5s ease-out 0s)); }


### PR DESCRIPTION
I updated the basic browser support matrix, and removed the crazy-old webkit workaround. I also removed the old code for prefixing transitioned properties, because it was over-simplistic. 

It would be nice to add that back in, with a more robust approach, but I couldn't figure out a way to make it happen. Help, @chriseppstein or @scottdavis ?

I did update the tests, so they fail currently, but should pass if you get it working. I also updated `$transitionable-prefixed-values` so it shows a list of values and the prefixes that should be applied to them.
