### PR TITLE
Inline block list update

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
+++ b/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
@@ -45,7 +45,7 @@
 
 // Can be mixed into any li selector that is meant to participate in a horizontal layout.
 // Used to implement `inline-block-list`.
-@mixin inline-block-list-item($padding: false) {
+@mixin inline-block-list-item($padding: false, $direction: left) {
   @include no-bullet;
   @include inline-block;
   white-space: nowrap;
@@ -53,14 +53,12 @@
     padding: {
       left: $padding;
       right: $padding;
-    };    
+    };
+    &:first-child #{if($legacy-support-for-ie6, ', &.first', '')} { padding-#{$direction}: 0; }
+    &:last-child { padding-#{opposite-position($direction)}: 0; }
+    @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
+      &.last { padding-#{opposite-position($direction)}: 0; } }
   }
-  // Not sure if we need to set these based on the direction
-  // since we can't set the direction of the list like we
-  // can when they are floated?
-  &:first-child, &.first { padding-left: 0; }
-  &:last-child { padding-right: 0; }
-  &.last { padding-left: 0; }
 }
 
 // A list(ol,ul) that is layed out such that the elements are inline-block and won't wrap.

--- a/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
+++ b/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
@@ -55,6 +55,12 @@
       right: $padding;
     };    
   }
+  // Not sure if we need to set these based on the direction
+  // since we can't set the direction of the list like we
+  // can when they are floated?
+  &:first-child, &.first { padding-left: 0; }
+  &:last-child { padding-right: 0; }
+  &.last { padding-left: 0; }
 }
 
 // A list(ol,ul) that is layed out such that the elements are inline-block and won't wrap.

--- a/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
+++ b/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
@@ -26,18 +26,29 @@
 
 // Can be mixed into any selector that target a ul or ol that is meant
 // to have an inline-block layout. Used to implement `inline-block-list`.
-@mixin inline-block-list-container($remove-inline-block-gap: true, $legacy-opera-support: false) {
+@mixin inline-block-list-container($remove-inline-block-gap: true, $legacy-opera-support: false, $monospaced-font: false) {
   
   // do we need to use clearfix and reset the box model?
   // I don't see why
   @include horizontal-list-container;
-
+  
+  // Remove inter-unit whitespace that appears between `inline-block` child
+  // elements. Work for all non-monospace font-families.  If you're using a
+  // monospace base font, you will need to set the `Grid` font-family to
+  // `sans-serif` and then redeclare the monospace font on the `Grid-cell`
+  // objects.
   @if $remove-inline-block-gap {
     letter-spacing: -0.31em;
     @if $legacy-opera-support {
       &:-o-prefocus,
       & {
         word-spacing: -0.43em; //Opera 12 Windows
+      }
+    }
+    @if $monospaced-font {
+      font-family: 'sans-serif';
+      li {
+        font-family: $monospaced-font;
       }
     }
   }

--- a/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
+++ b/frameworks/compass/stylesheets/compass/typography/lists/_inline-block-list.scss
@@ -26,8 +26,22 @@
 
 // Can be mixed into any selector that target a ul or ol that is meant
 // to have an inline-block layout. Used to implement `inline-block-list`.
-@mixin inline-block-list-container {
-  @include horizontal-list-container; }
+@mixin inline-block-list-container($remove-inline-block-gap: true, $legacy-opera-support: false) {
+  
+  // do we need to use clearfix and reset the box model?
+  // I don't see why
+  @include horizontal-list-container;
+
+  @if $remove-inline-block-gap {
+    letter-spacing: -0.31em;
+    @if $legacy-opera-support {
+      &:-o-prefocus,
+      & {
+        word-spacing: -0.43em; //Opera 12 Windows
+      }
+    }
+  }
+}
 
 // Can be mixed into any li selector that is meant to participate in a horizontal layout.
 // Used to implement `inline-block-list`.


### PR DESCRIPTION
Two changes/improvements to inline block lists
## inline-block-list-container

Add option to compensate for whitespace gap caused by by using inline-block. This is done with negative letter-spacing (the approach taken by yui (http://yui.yahooapis.com/3.5.0/build/cssgrids/grids.css).

This works well for mainstream browsers (legacy IE included despite what yui comments say) expect Opera 12 on windows. Added something to compensate for that as well (negative word spacing). Since compass doesn't have a $legacy-opera flag I don't know if this is even necessary?

Also not sure if horizontal-list-container is needed in inline list container. Don't think we need to clearfix and reset the box model?
## inline-block-list-item

Set relevant horizontal padding to 0 for first and last elements in the list. Also added the direction argument in order to set the 0 padding appropriately. Since you can't set list order not sure if necessary needed but overal I think it is nice to include what support is possible to right to left languages.

Also why was padding and not margin chosen as the separating property on list? Would the option to allow margin separators be useful.
## Todo

If this sounds vaguely reasonable I need to
1. Add tests
2. Add functionality to set the commentating letter-spacing in values other then em based on values set by the vertical rhythm module. Would be nice to set it to rems or rems with pixel fallbacks.
