### PR TITLE
Fix for issue #1207

### DIFF
--- a/lib/compass/sass_extensions/functions/urls.rb
+++ b/lib/compass/sass_extensions/functions/urls.rb
@@ -247,7 +247,7 @@ module Compass::SassExtensions::Functions::Urls
     if Compass.configuration.asset_cache_buster
       args = [path]
       if Compass.configuration.asset_cache_buster.arity > 1
-        args << (File.new(real_path) if real_path)
+        args << real_path
       end
       Compass.configuration.asset_cache_buster.call(*args)
     elsif real_path


### PR DESCRIPTION
The documentation indicates that the second argument passed
to an asset_cache_buster method will be a string, but a File
is passed instead.

This poses the following problems:
1. A fatal error occurs if the file does not exist
2. The file descriptor is left open if the file exists

This commit addresses the issue by passing the real_path to
the provided asset_cache_buster method instead of a File instance
