### PR TITLE
Support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
+  - 2.0
   - jruby-18mode
   - jruby-19mode
   - rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec
 

--- a/compass.gemspec
+++ b/compass.gemspec
@@ -1,3 +1,5 @@
+require "date"
+
 path = "#{File.dirname(__FILE__)}/lib"
 require File.join(path, 'compass/version')
 

--- a/test/helpers/rails.rb
+++ b/test/helpers/rails.rb
@@ -24,7 +24,7 @@ module Compass
           if ActionPack::VERSION::MAJOR >= 3
             require 'rails/generators'
             require 'rails/generators/rails/app/app_generator'
-            require 'mocha'
+            require 'mocha/setup'
             dir ||= File.join(File.expand_path('../../', __FILE__))
             args = [File.join(dir, name), '-q', '-f', '--skip-bundle', '--skip-gemfile']
             

--- a/test/helpers/test_case.rb
+++ b/test/helpers/test_case.rb
@@ -39,12 +39,6 @@ module Compass
         define_method "test_#{underscore(name)}".to_sym, &block
       end
 
-      def setup(&block)
-        define_method :setup do
-          yield
-        end
-      end
-
       def after(&block)
         define_method :teardown do
           yield

--- a/test/units/sprites/image_test.rb
+++ b/test/units/sprites/image_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'mocha'
+require 'mocha/setup'
 require 'ostruct'
 
 class SpritesImageTest < Test::Unit::TestCase


### PR DESCRIPTION
Hi guys,

I searched through open issues and pull request and couldn't find anything related to Ruby 2.0. So, following up on [an issue with compass-rails to support rails 4](https://github.com/Compass/compass-rails/pull/59#issuecomment-14795802), I started to fix some problems with Compass running on Ruby 2.0.0-p0. With these changes, the tests are running (as you should hopefully see on Travis), but I still see 2 failures and 1 error.

Also, I'm not sure about the change to the test helper class. I only spend a couple of minutes in the codebase and I'm not sure why the helper even exists. Convenience or backwards compatibility maybe? So please let me know if my "fix" to support Mocha is actually stupid or not.

Ps. These changes currently only fix basic integration problems and I hope to get those fixed so we can concentrate on the "real" problems.

Cheers,
Daniel
