### PR TITLE
Do not set --force when passing files as arguments

### DIFF
--- a/lib/compass/commands/update_project.rb
+++ b/lib/compass/commands/update_project.rb
@@ -129,7 +129,6 @@ module Compass
             parser.options[:project_name] = arguments.shift if File.directory?(arguments.first)
             unless arguments.empty?
               parser.options[:sass_files] = arguments.dup
-              parser.options[:force] = true
             end
           end
         end


### PR DESCRIPTION
There is no need to set force to true here since compass already
has a --force true option and sass/compass does a very good job on
detecting files that changed.

My use case for using compass with django-pipeline, in which it will
force compilation every request while developing (DEBUG=True there).

Its not possible to use `compass watch` because the files are going to
be inside the installed apps, that could be anywhere, even outside
your project folder.
