### PR TITLE
Full height sticky footer

### DIFF
--- a/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
+++ b/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
@@ -6,7 +6,7 @@
 //
 // Footer must be a fixed height.
 
-@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer")) {
+@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer"), $full-height-selctor: unquote(".full-height")) {
   html, body {
     height: 100%; }
   #{$root-selector} {
@@ -15,6 +15,13 @@
     height: auto !important;
     height: 100%;
     margin-bottom: -$footer-height;
+    #{$full-height-selector} {
+      min-height: -moz-calc( 100% - #{$footer-height}) )
+      min-height: -o-calc( 100% - #{$footer-height}) )
+      min-height: -webkit-calc( 100% - #{$footer-height}) )
+      min-height: calc( 100% - #{$footer-height}) )
+      position: absolute
+    }
     #{$root-footer-selector} {
       height: $footer-height; } }
   #{$footer-selector} {

--- a/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
+++ b/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
@@ -5,8 +5,10 @@
 // Footer element must be outside of root wrapper element.
 //
 // Footer must be a fixed height.
+//
+// Root must be positioned relative in order for the FullHeightSelector to work.
 
-@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer"), $full-height-selctor: unquote(".full_height")) {
+@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer"), $full-height-selector: unquote(".full_height")) {
   html, body {
     height: 100%; }
   #{$root-selector} {

--- a/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
+++ b/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
@@ -6,7 +6,7 @@
 //
 // Footer must be a fixed height.
 
-@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer"), $full-height-selctor: unquote(".full-height")) {
+@mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer"), $full-height-selctor: unquote(".full_height")) {
   html, body {
     height: 100%; }
   #{$root-selector} {
@@ -16,12 +16,11 @@
     height: 100%;
     margin-bottom: -$footer-height;
     #{$full-height-selector} {
-      min-height: -moz-calc( 100% - #{$footer-height}) )
-      min-height: -o-calc( 100% - #{$footer-height}) )
-      min-height: -webkit-calc( 100% - #{$footer-height}) )
-      min-height: calc( 100% - #{$footer-height}) )
-      position: absolute
-    }
+      min-height: -moz-calc( 100% - #{$footer-height});
+      min-height: -o-calc( 100% - #{$footer-height});
+      min-height: -webkit-calc( 100% - #{$footer-height});
+      min-height: calc( 100% - #{$footer-height});
+      position: absolute; }
     #{$root-footer-selector} {
       height: $footer-height; } }
   #{$footer-selector} {


### PR DESCRIPTION
I've added functionality to the sticky-footer class that allows for full-height elements that will stretch the full length of the document, ending wherever the sticky footer begins. 

It leverages the calc() css function and relies on a relatively positioned root, the latter of which I have kept out of this so as to avoid magic behavior. Since you all have a much more top-down idea of how compass works, I'll leave it to your discretion as to whether or not it should be default. 

With this change, you can make any element on the page stretch from the Top of the root to the sticky footer by adding the class '.full_height'. 
