### PR TITLE
Update urls.haml to fix small typo

### DIFF
--- a/doc-src/content/reference/compass/helpers/urls.haml
+++ b/doc-src/content/reference/compass/helpers/urls.haml
@@ -31,7 +31,7 @@ documented_functions:
     %p
       Generates a path to an asset found relative to the project's css directory.
       %br
-      Passing a true value as the second argument will cause the only the path to be returned
+      Passing a true value as the second argument will cause pronly the path to be returned
       instead of a <code>url()</code> function
 
 #font-url.helper
@@ -42,7 +42,7 @@ documented_functions:
     %p
       Generates a path to an asset found relative to the project's font directory.
       %br
-      Passing a true value as the second argument will cause the only the path to be returned
+      Passing a true value as the second argument will cause only the path to be returned
       instead of a <code>url()</code> function
 
 #image-url.helper
@@ -53,7 +53,7 @@ documented_functions:
     %p
       Generates a path to an asset found relative to the project's images directory.
     %p
-      Passing a true value as the second argument will cause the only the path to be returned
+      Passing a true value as the second argument will cause only the path to be returned
       instead of a <code>url()</code> function
     %p
       The third argument is used to control the cache buster on a per-use basis.


### PR DESCRIPTION
Typos. Remove extranous "the" in three places.
