### PR TITLE
Fix in math docs

### DIFF
--- a/doc-src/content/reference/compass/helpers/math.haml
+++ b/doc-src/content/reference/compass/helpers/math.haml
@@ -73,8 +73,8 @@ documented_functions:
 
 #asin.helper
   %h3
-    %a(href="a#sin")
-      sin(<span class="arg">$number</span>)
+    %a(href="#asin")
+      asin(<span class="arg">$number</span>)
   .details
     %p
       Returns the arcsine of a number. If the number is unitless or has a unit of <code>deg</code>
@@ -86,7 +86,7 @@ documented_functions:
 #acos.helper
   %h3
     %a(href="#acos")
-      cos(<span class="arg">$number</span>)
+      acos(<span class="arg">$number</span>)
   .details
     %p
       Returns the arccosine of a number. If the number is unitless or has a unit of <code>deg</code>
@@ -98,7 +98,7 @@ documented_functions:
 #atan.helper
   %h3
     %a(href="#atan")
-      tan(<span class="arg">$number</span>)
+      atan(<span class="arg">$number</span>)
   .details
     %p
       Returns the arctangent of a number. If the number is unitless or has a unit of <code>deg</code>


### PR DESCRIPTION
My previous commit left some incorrect references to the existing trig functions that I copied the docs from.
