### PR TITLE
Add --output-dir option to output generated css files to a different directory

### DIFF
--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -18,17 +18,17 @@ Feature: Command Line
     And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
 
   Scenario: Install a project without a framework and separate output-dir
-    Given I should clean up the directory: my_project_output
-    When I create a project using: compass create my_project --output-dir my_project_output
+    Given I should clean up the directory: out
+    When I create a project using: compass create my_project --output-dir out
     Then a directory my_project/ is created
-    And a directory my_project_output/ is created
+    And a directory out/ is created
     And a configuration file my_project/config.rb is created
     And a sass file my_project/sass/screen.scss is created
     And a sass file my_project/sass/print.scss is created
     And a sass file my_project/sass/ie.scss is created
-    And a css file my_project_output/screen.css is created
-    And a css file my_project_output/print.css is created
-    And a css file my_project_output/ie.css is created
+    And a css file out/stylesheets/screen.css is created
+    And a css file out/stylesheets/print.css is created
+    And a css file out/stylesheets/ie.css is created
     And I am told how to link to /stylesheets/screen.css for media "screen, projection"
     And I am told how to link to /stylesheets/print.css for media "print"
     And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
@@ -42,14 +42,14 @@ Feature: Command Line
     And a css file custom_project/css/screen.css is created
 
   Scenario: Install a project with specific directories and separate output dir
-    Given I should clean up the directory: custom_project_css
-    When I create a project using: compass create custom_project --using compass --sass-dir sass --css-dir css --images-dir assets/imgs --output-dir custom_project_css
+    Given I should clean up the directory: custom_out
+    When I create a project using: compass create custom_project --using compass --sass-dir sass --css-dir css --images-dir assets/imgs --output-dir custom_out
     Then a directory custom_project/ is created
-    And a directory custom_project_css/ is created
+    And a directory custom_out/ is created
     And a directory custom_project/sass/ is created
     And a directory custom_project/css/ is created
     And a sass file custom_project/sass/screen.scss is created
-    And a css file custom_project_css/screen.css is created
+    And a css file custom_out/css/screen.css is created
 
   Scenario: Perform a dry run of creating a project
     When I create a project using: compass create my_project --dry-run
@@ -63,9 +63,9 @@ Feature: Command Line
     And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
 
   Scenario: Perform a dry run of creating a project with separate output dir
-    When I create a project using: compass create my_project --output-dir my_project_dir --dry-run
+    When I create a project using: compass create my_project --output-dir out --dry-run
     Then a directory my_project/ is not created
-    And a directory my_project_dir/ is not created
+    And a directory out/ is not created
     But a configuration file my_project/config.rb is reported created
     And a sass file my_project/sass/screen.scss is reported created
     And a sass file my_project/sass/print.scss is reported created
@@ -126,19 +126,22 @@ Feature: Command Line
     And a css file tmp/print.css is created
     And a css file tmp/reset.css is created
     And a css file tmp/utilities.css is created
-    When I run: compass compile --output-dir tmp-css 
-    Then a directory tmp-css/ is created
-    And a css file tmp-css/layout.css is created
-    And tmp-css/layout.css and tmp/layout.css are the same
-    And a css file tmp-css/print.css is created
-    And tmp-css/print.css and tmp/print.css are the same
-    And a css file tmp-css/reset.css is created
-    And tmp-css/reset.css and tmp/reset.css are the same
-    And a css file tmp-css/utilities.css is created
-    And tmp-css/utilities.css and tmp/utilities.css are the same
+    When I run: compass compile --output-dir out
+    Then a directory out/ is created
+    And a css file out/tmp/layout.css is created
+    And out/tmp/layout.css and tmp/layout.css are the same
+    And a css file out/tmp/print.css is created
+    And out/tmp/print.css and tmp/print.css are the same
+    And a css file out/tmp/reset.css is created
+    And out/tmp/reset.css and tmp/reset.css are the same
+    And a css file out/tmp/utilities.css is created
+    And out/tmp/utilities.css and tmp/utilities.css are the same
 
   Scenario: Compiling an existing project with a separate output-dir and relative-assets
     Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --css-dir tmp-css/css/ --relative-assets
+    Then a directory tmp-css/css/ is created
+    And a css file tmp-css/css/sprites.css is created
     When I run: compass compile --relative-assets
     Then a directory tmp/ is created
     And a css file tmp/layout.css is created
@@ -147,13 +150,10 @@ Feature: Command Line
     And a css file tmp/utilities.css is created
     And a css file tmp/sprites.css is created
     When I run: compass compile --output-dir tmp-output/css/ --relative-assets
-    And a css file tmp-output/css/sprites.css is created
-    And tmp-output/css/sprites.css and tmp/sprites.css are the same
-    When I run: compass compile --css-dir tmp-css/css/ --relative-assets
-    Then a directory tmp-css/css/ is created
-    And a css file tmp-output/css/sprites.css is created
+    And a css file tmp-output/css/tmp/sprites.css is created
+    And tmp-output/css/tmp/sprites.css and tmp/sprites.css are the same
     But tmp-css/css/sprites.css and tmp/sprites.css are not the same
-    And tmp-css/css/sprites.css and tmp-output/css/sprites.css are not the same
+    And tmp-css/css/sprites.css and tmp-output/css/tmp/sprites.css are not the same
 
   Scenario: Compiling an existing project with a specified project
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -168,14 +168,14 @@ Feature: Command Line
   Scenario: Compiling an existing project with a specified project with an output-dir
     Given I am using the existing project in test/fixtures/stylesheets/compass
     And I am in the parent directory
-    And I should clean up the directory: tmp_compass_tmp
-    When I run: compass compile tmp_compass --output-dir tmp_compass_tmp
-    Then a directory tmp_compass_tmp/ is created
+    And I should clean up the directory: out
+    When I run: compass compile tmp_compass --output-dir out
+    Then a directory out/ is created
     But a directory tmp_compass/tmp is not created
-    And a css file tmp_compass_tmp/layout.css is created
-    And a css file tmp_compass_tmp/print.css is created
-    And a css file tmp_compass_tmp/reset.css is created
-    And a css file tmp_compass_tmp/utilities.css is created
+    And a css file out/tmp/layout.css is created
+    And a css file out/tmp/print.css is created
+    And a css file out/tmp/reset.css is created
+    And a css file out/tmp/utilities.css is created
 
   Scenario: Dry Run of Compiling an existing project.
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -206,12 +206,12 @@ Feature: Command Line
 
   Scenario: compiling a specific file in a project with output-dir
     Given I am using the existing project in test/fixtures/stylesheets/compass
-    And I run: compass compile sass/utilities.scss --output-dir css_tmp
+    And I run: compass compile sass/utilities.scss --output-dir out
     Then a sass file sass/layout.sass is not mentioned
     And a sass file sass/print.sass is not mentioned
     And a sass file sass/reset.sass is not mentioned
-    And a css file css_tmp/utilities.css is reported created
-    And a css file css_tmp/utilities.css is created
+    And a css file out/tmp/utilities.css is reported created
+    And a css file out/tmp/utilities.css is created
 
   Scenario: Re-compiling a specific file in a project with no changes
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -229,7 +229,7 @@ Feature: Command Line
     Then a sass file sass/layout.sass is not mentioned
     And a sass file sass/print.sass is not mentioned
     And a sass file sass/reset.sass is not mentioned
-    And a css file tmp-css/utilities.css is reported identical
+    And a css file tmp-css/tmp/utilities.css is reported identical
 
   Scenario: Re-compiling a specific file in a project with no changes but a new output-dir
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -238,7 +238,7 @@ Feature: Command Line
     Then a sass file sass/layout.sass is not mentioned
     And a sass file sass/print.sass is not mentioned
     And a sass file sass/reset.sass is not mentioned
-    And a css file tmp/utilities.css is created
+    And a css file css_tmp/tmp/utilities.css is created
 
   Scenario: Installing a pattern into a project
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -289,7 +289,7 @@ Feature: Command Line
     And I wait 1 second
     And I touch sass/layout.sass
     And I run: compass compile --output-dir test-css
-    Then a css file test-css/layout.css is reported identical
+    Then a css file test-css/tmp/layout.css is reported identical
 
   Scenario: Recompiling a project with output-dir and changes
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -297,7 +297,7 @@ Feature: Command Line
     And I wait 1 second
     And I add some sass to sass/layout.sass
     And I run: compass compile --output-dir test-css
-    And a css file test-css/layout.css is reported overwritten
+    And a css file test-css/tmp/layout.css is reported overwritten
 
   Scenario: Cleaning a project
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -322,23 +322,23 @@ Feature: Command Line
 
   Scenario: Cleaning a project with output-dir 
     Given I am using the existing project in test/fixtures/stylesheets/compass
-    When I run: compass compile --output-dir output-dir
-    And I run: compass clean --output-dir output-dir
+    When I run: compass compile --output-dir output
+    And I run: compass clean --output-dir output
     Then the following files are reported removed:
       | .sass-cache/                 |
-      | output-dir/border_radius.css |
-      | output-dir/box.css           |
-      | output-dir/box_shadow.css    |
-      | output-dir/columns.css       |
-      | output-dir/fonts.css         |
+      | output/tmp/border_radius.css |
+      | output/tmp/box.css           |
+      | output/tmp/box_shadow.css    |
+      | output/tmp/columns.css       |
+      | output/tmp/fonts.css         |
       | images/flag-s5b4f509715.png  |
     And the following files are removed:
       | .sass-cache/                 |
-      | output-dir/border_radius.css |
-      | output-dir/box.css           |
-      | output-dir/box_shadow.css    |
-      | output-dir/columns.css       |
-      | output-dir/fonts.css         |
+      | output/tmp/border_radius.css |
+      | output/tmp/box.css           |
+      | output/tmp/box_shadow.css    |
+      | output/tmp/columns.css       |
+      | output/tmp/fonts.css         |
       | images/flag-s5b4f509715.png  |
 
   Scenario: Watching a project for changes
@@ -355,13 +355,13 @@ Feature: Command Line
   Scenario: Watching a project with output-dir for changes
     Given ruby supports fork
     Given I am using the existing project in test/fixtures/stylesheets/compass
-    When I run: compass compile --output-dir output-dir
-    And I run in a separate process: compass watch --output-dir output-dir
+    When I run: compass compile --output-dir output
+    And I run in a separate process: compass watch --output-dir output
     And I wait 3 seconds
     And I touch sass/layout.sass
     And I wait 2 seconds
     And I shutdown the other process
-    Then a css file output-dir/layout.css is reported identical
+    Then a css file output/tmp/layout.css is reported identical
 
   Scenario: Generate a compass configuration file
     Given I should clean up the directory: config

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -17,6 +17,22 @@ Feature: Command Line
     And I am told how to link to /stylesheets/print.css for media "print"
     And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
 
+  Scenario: Install a project without a framework and separate output-dir
+    Given I should clean up the directory: my_project_output
+    When I create a project using: compass create my_project --output-dir my_project_output
+    Then a directory my_project/ is created
+    And a directory my_project_output/ is created
+    And a configuration file my_project/config.rb is created
+    And a sass file my_project/sass/screen.scss is created
+    And a sass file my_project/sass/print.scss is created
+    And a sass file my_project/sass/ie.scss is created
+    And a css file my_project_output/screen.css is created
+    And a css file my_project_output/print.css is created
+    And a css file my_project_output/ie.css is created
+    And I am told how to link to /stylesheets/screen.css for media "screen, projection"
+    And I am told how to link to /stylesheets/print.css for media "print"
+    And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
+
   Scenario: Install a project with specific directories
     When I create a project using: compass create custom_project --using compass --sass-dir sass --css-dir css --images-dir assets/imgs
     Then a directory custom_project/ is created
@@ -24,6 +40,16 @@ Feature: Command Line
     And a directory custom_project/css/ is created
     And a sass file custom_project/sass/screen.scss is created
     And a css file custom_project/css/screen.css is created
+
+  Scenario: Install a project with specific directories and separate output dir
+    Given I should clean up the directory: custom_project_css
+    When I create a project using: compass create custom_project --using compass --sass-dir sass --css-dir css --images-dir assets/imgs --output-dir custom_project_css
+    Then a directory custom_project/ is created
+    And a directory custom_project_css/ is created
+    And a directory custom_project/sass/ is created
+    And a directory custom_project/css/ is created
+    And a sass file custom_project/sass/screen.scss is created
+    And a css file custom_project_css/screen.css is created
 
   Scenario: Perform a dry run of creating a project
     When I create a project using: compass create my_project --dry-run
@@ -36,9 +62,32 @@ Feature: Command Line
     And I am told how to link to /stylesheets/print.css for media "print"
     And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
 
+  Scenario: Perform a dry run of creating a project with separate output dir
+    When I create a project using: compass create my_project --output-dir my_project_dir --dry-run
+    Then a directory my_project/ is not created
+    And a directory my_project_dir/ is not created
+    But a configuration file my_project/config.rb is reported created
+    And a sass file my_project/sass/screen.scss is reported created
+    And a sass file my_project/sass/print.scss is reported created
+    And a sass file my_project/sass/ie.scss is reported created
+    And I am told how to link to /stylesheets/screen.css for media "screen, projection"
+    And I am told how to link to /stylesheets/print.css for media "print"
+    And I am told how to conditionally link "IE" to /stylesheets/ie.css for media "screen, projection"
+
   Scenario: Creating a bare project
     When I create a project using: compass create bare_project --bare
     Then a directory bare_project/ is created
+    And a configuration file bare_project/config.rb is created
+    And a directory bare_project/sass/ is created
+    And a directory bare_project/stylesheets/ is not created
+    And I am congratulated
+    And I am told that I can place stylesheets in the sass subdirectory
+    And I am told how to compile my sass stylesheets
+
+  Scenario: Creating a bare project with separate output dir
+    When I create a project using: compass create bare_project --bare --output-dir bare_output
+    Then a directory bare_project/ is created
+    And a directory bare_output/ is not created
     And a configuration file bare_project/config.rb is created
     And a directory bare_project/sass/ is created
     And a directory bare_project/stylesheets/ is not created
@@ -69,6 +118,43 @@ Feature: Command Line
     And a css file tmp/reset.css is created
     And a css file tmp/utilities.css is created
 
+  Scenario: Compiling an existing project with a separate output-dir
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile
+    Then a directory tmp/ is created
+    And a css file tmp/layout.css is created
+    And a css file tmp/print.css is created
+    And a css file tmp/reset.css is created
+    And a css file tmp/utilities.css is created
+    When I run: compass compile --output-dir tmp-css 
+    Then a directory tmp-css/ is created
+    And a css file tmp-css/layout.css is created
+    And tmp-css/layout.css and tmp/layout.css are the same
+    And a css file tmp-css/print.css is created
+    And tmp-css/print.css and tmp/print.css are the same
+    And a css file tmp-css/reset.css is created
+    And tmp-css/reset.css and tmp/reset.css are the same
+    And a css file tmp-css/utilities.css is created
+    And tmp-css/utilities.css and tmp/utilities.css are the same
+
+  Scenario: Compiling an existing project with a separate output-dir and relative-assets
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --relative-assets
+    Then a directory tmp/ is created
+    And a css file tmp/layout.css is created
+    And a css file tmp/print.css is created
+    And a css file tmp/reset.css is created
+    And a css file tmp/utilities.css is created
+    And a css file tmp/sprites.css is created
+    When I run: compass compile --output-dir tmp-output/css/ --relative-assets
+    And a css file tmp-output/css/sprites.css is created
+    And tmp-output/css/sprites.css and tmp/sprites.css are the same
+    When I run: compass compile --css-dir tmp-css/css/ --relative-assets
+    Then a directory tmp-css/css/ is created
+    And a css file tmp-output/css/sprites.css is created
+    But tmp-css/css/sprites.css and tmp/sprites.css are not the same
+    And tmp-css/css/sprites.css and tmp-output/css/sprites.css are not the same
+
   Scenario: Compiling an existing project with a specified project
     Given I am using the existing project in test/fixtures/stylesheets/compass
     And I am in the parent directory
@@ -78,6 +164,18 @@ Feature: Command Line
     And a css file tmp_compass/tmp/print.css is created
     And a css file tmp_compass/tmp/reset.css is created
     And a css file tmp_compass/tmp/utilities.css is created
+
+  Scenario: Compiling an existing project with a specified project with an output-dir
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    And I am in the parent directory
+    And I should clean up the directory: tmp_compass_tmp
+    When I run: compass compile tmp_compass --output-dir tmp_compass_tmp
+    Then a directory tmp_compass_tmp/ is created
+    But a directory tmp_compass/tmp is not created
+    And a css file tmp_compass_tmp/layout.css is created
+    And a css file tmp_compass_tmp/print.css is created
+    And a css file tmp_compass_tmp/reset.css is created
+    And a css file tmp_compass_tmp/utilities.css is created
 
   Scenario: Dry Run of Compiling an existing project.
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -106,6 +204,15 @@ Feature: Command Line
     And a css file tmp/utilities.css is reported created
     And a css file tmp/utilities.css is created
 
+  Scenario: compiling a specific file in a project with output-dir
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    And I run: compass compile sass/utilities.scss --output-dir css_tmp
+    Then a sass file sass/layout.sass is not mentioned
+    And a sass file sass/print.sass is not mentioned
+    And a sass file sass/reset.sass is not mentioned
+    And a css file css_tmp/utilities.css is reported created
+    And a css file css_tmp/utilities.css is created
+
   Scenario: Re-compiling a specific file in a project with no changes
     Given I am using the existing project in test/fixtures/stylesheets/compass
     When I run: compass compile
@@ -114,6 +221,24 @@ Feature: Command Line
     And a sass file sass/print.sass is not mentioned
     And a sass file sass/reset.sass is not mentioned
     And a css file tmp/utilities.css is reported identical
+
+  Scenario: Re-compiling a specific file in a project with output-dir but no changes
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --output-dir tmp-css
+    And I run: compass compile sass/utilities.scss --output-dir tmp-css --force
+    Then a sass file sass/layout.sass is not mentioned
+    And a sass file sass/print.sass is not mentioned
+    And a sass file sass/reset.sass is not mentioned
+    And a css file tmp-css/utilities.css is reported identical
+
+  Scenario: Re-compiling a specific file in a project with no changes but a new output-dir
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile
+    And I run: compass compile sass/utilities.scss --output-dir css_tmp
+    Then a sass file sass/layout.sass is not mentioned
+    And a sass file sass/print.sass is not mentioned
+    And a sass file sass/reset.sass is not mentioned
+    And a css file tmp/utilities.css is created
 
   Scenario: Installing a pattern into a project
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -158,6 +283,22 @@ Feature: Command Line
     And I run: compass compile
     And a css file tmp/layout.css is reported overwritten
 
+  Scenario: Recompiling a project with output-dir and no material changes
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --output-dir test-css
+    And I wait 1 second
+    And I touch sass/layout.sass
+    And I run: compass compile --output-dir test-css
+    Then a css file test-css/layout.css is reported identical
+
+  Scenario: Recompiling a project with output-dir and changes
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --output-dir test-css
+    And I wait 1 second
+    And I add some sass to sass/layout.sass
+    And I run: compass compile --output-dir test-css
+    And a css file test-css/layout.css is reported overwritten
+
   Scenario: Cleaning a project
     Given I am using the existing project in test/fixtures/stylesheets/compass
     When I run: compass compile
@@ -179,6 +320,27 @@ Feature: Command Line
       | tmp/fonts.css               |
       | images/flag-s5b4f509715.png |
 
+  Scenario: Cleaning a project with output-dir 
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --output-dir output-dir
+    And I run: compass clean --output-dir output-dir
+    Then the following files are reported removed:
+      | .sass-cache/                 |
+      | output-dir/border_radius.css |
+      | output-dir/box.css           |
+      | output-dir/box_shadow.css    |
+      | output-dir/columns.css       |
+      | output-dir/fonts.css         |
+      | images/flag-s5b4f509715.png  |
+    And the following files are removed:
+      | .sass-cache/                 |
+      | output-dir/border_radius.css |
+      | output-dir/box.css           |
+      | output-dir/box_shadow.css    |
+      | output-dir/columns.css       |
+      | output-dir/fonts.css         |
+      | images/flag-s5b4f509715.png  |
+
   Scenario: Watching a project for changes
     Given ruby supports fork
     Given I am using the existing project in test/fixtures/stylesheets/compass
@@ -188,7 +350,18 @@ Feature: Command Line
     And I touch sass/layout.sass
     And I wait 2 seconds
     And I shutdown the other process
-    Then a css file tmp/layout.css is reported identical\
+    Then a css file tmp/layout.css is reported identical
+
+  Scenario: Watching a project with output-dir for changes
+    Given ruby supports fork
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    When I run: compass compile --output-dir output-dir
+    And I run in a separate process: compass watch --output-dir output-dir
+    And I wait 3 seconds
+    And I touch sass/layout.sass
+    And I wait 2 seconds
+    And I shutdown the other process
+    Then a css file output-dir/layout.css is reported identical
 
   Scenario: Generate a compass configuration file
     Given I should clean up the directory: config

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -339,7 +339,7 @@ Feature: Command Line
       | output/tmp/box_shadow.css    |
       | output/tmp/columns.css       |
       | output/tmp/fonts.css         |
-      | images/flag-s5b4f509715.png  |
+      | output/images/flag-s5b4f509715.png  |
 
   Scenario: Watching a project for changes
     Given ruby supports fork

--- a/features/step_definitions/command_line_steps.rb
+++ b/features/step_definitions/command_line_steps.rb
@@ -3,6 +3,7 @@ $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), '../../test')))
 require 'test_helper'
 
 require 'compass/exec'
+require 'fileutils'
 include Compass::TestCaseHelper
 include Compass::CommandLineHelper
 include Compass::IoHelper
@@ -137,6 +138,10 @@ end
 
 Then /an? \w+ file ([^ ]+) is reported removed/ do |filename|
   @last_result.should =~ /remove.*#{Regexp.escape(filename)}/
+end
+
+Then /([^ ]+) and ([^ ]+) are (not )?the same/ do |file1, file2, negated|
+    FileUtils.compare_file(file1, file2).should == !negated
 end
 
 Then /an? \w+ file ([^ ]+) is reported created/ do |filename|

--- a/lib/compass/actions.rb
+++ b/lib/compass/actions.rb
@@ -80,17 +80,9 @@ module Compass
     end
 
     def basename(file)
-      relativize(file) {|f| File.basename(file)}
-    end
-
-    def relativize(path)
-      if path.index(working_path+File::SEPARATOR) == 0
-        path[(working_path+File::SEPARATOR).length..-1]
-      elsif block_given?
-        yield path
-      else
-        path
-      end
+      p1 = Pathname.new(File.expand_path(file, working_path+File::SEPARATOR))
+      p2 = Pathname.new(working_path)
+      p1.relative_path_from(p2)
     end
 
     # Write paths like we're on unix and then fix it

--- a/lib/compass/actions.rb
+++ b/lib/compass/actions.rb
@@ -82,7 +82,7 @@ module Compass
     def basename(file)
       p1 = Pathname.new(File.expand_path(file, working_path+File::SEPARATOR))
       p2 = Pathname.new(working_path)
-      p1.relative_path_from(p2)
+      p1.relative_path_from(p2).to_s
     end
 
     # Write paths like we're on unix and then fix it

--- a/lib/compass/commands/clean_project.rb
+++ b/lib/compass/commands/clean_project.rb
@@ -30,7 +30,7 @@ module Compass
       def perform
         compiler = new_compiler_instance
         compiler.clean!
-        Compass::SpriteImporter.find_all_sprite_map_files(Compass.configuration.generated_images_path).each do |sprite|
+        Compass::SpriteImporter.find_all_sprite_map_files(Compass.configuration.output_generated_images_path).each do |sprite|
           remove sprite
         end
       end

--- a/lib/compass/compiler.rb
+++ b/lib/compass/compiler.rb
@@ -11,7 +11,7 @@ module Compass
       self.logger = options.delete(:logger)
       sass_opts = options.delete(:sass) || {}
       self.options = options
-      self.output_to = options[:output_dir] || to
+      self.output_to = Compass.configuration.output_css_path || to
       self.sass_options = options.dup
       self.sass_options.delete(:quiet)
       self.sass_options.update(sass_opts)

--- a/lib/compass/compiler.rb
+++ b/lib/compass/compiler.rb
@@ -3,7 +3,7 @@ module Compass
 
     include Actions
 
-    attr_accessor :working_path, :from, :to, :options, :sass_options, :staleness_checker, :importer
+    attr_accessor :working_path, :from, :to, :options, :sass_options, :staleness_checker, :importer, :output_to
 
     def initialize(working_path, from, to, options)
       self.working_path = working_path.to_s
@@ -11,6 +11,7 @@ module Compass
       self.logger = options.delete(:logger)
       sass_opts = options.delete(:sass) || {}
       self.options = options
+      self.output_to = options[:output_dir] || to
       self.sass_options = options.dup
       self.sass_options.delete(:quiet)
       self.sass_options.update(sass_opts)
@@ -54,6 +55,10 @@ module Compass
     end
 
     def corresponding_css_file(sass_file)
+      "#{output_to}/#{stylesheet_name(sass_file)}.css"
+    end
+
+    def virtual_css_file(sass_file)
       "#{to}/#{stylesheet_name(sass_file)}.css"
     end
 
@@ -143,7 +148,7 @@ module Compass
       start_time = end_time = nil
       css_content = logger.red do
         timed do
-          engine(sass_filename, css_filename).render
+          engine(sass_filename, virtual_css_file(sass_filename)).render
         end
       end
       duration = options[:time] ? "(#{(css_content.__duration * 1000).round / 1000.0}s)" : ""

--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -6,7 +6,9 @@ module Compass
         "#{dir_name}_dir",
         "#{dir_name}_path",
         ("http_#{http_dir_name}_dir" if http_dir_name),
-        ("http_#{http_dir_name}_path" if http_dir_name)
+        ("http_#{http_dir_name}_path" if http_dir_name),
+        ("output_#{dir_name}_dir" if http_dir_name),
+        ("output_#{dir_name}_path" if http_dir_name)
       ].compact.map{|a| a.to_sym}
     end
 
@@ -16,6 +18,7 @@ module Compass
       # Where is the project?
       :project_path,
       :http_path,
+      :output_path,
       # Where are the various bits of the project
       attributes_for_directory(:css, :stylesheets),
       attributes_for_directory(:sass, nil),

--- a/lib/compass/configuration/defaults.rb
+++ b/lib/compass/configuration/defaults.rb
@@ -54,6 +54,16 @@ module Compass
         end
       end
 
+      def default_output_css_path
+        if (pp = top_level.output_path) && (dir = top_level.output_css_dir)
+          Compass.projectize(dir, pp)
+        elsif (pp = top_level.output_path) && (dir = top_level.css_dir)
+          Compass.projectize(dir, pp)
+        elsif (pp = top_level.project_path) && (dir = top_level.css_dir)
+          Compass.projectize(dir, pp)
+        end
+      end
+
       def default_images_path
         if (pp = top_level.project_path) && (dir = top_level.images_dir)
           Compass.projectize(dir, pp)

--- a/lib/compass/configuration/defaults.rb
+++ b/lib/compass/configuration/defaults.rb
@@ -78,6 +78,18 @@ module Compass
         end
       end
 
+      def default_output_generated_images_path
+        if (pp = top_level.output_path) && (dir = top_level.output_generated_images_dir)
+          Compass.projectize(dir, pp)
+        elsif (pp = top_level.output_path) && (dir = top_level.generated_images_dir)
+          Compass.projectize(dir, pp)
+        elsif (pp = top_level.project_path) && (dir = top_level.generated_images_dir)
+          Compass.projectize(dir, pp)
+        else
+          top_level.generated_images_path
+        end
+      end
+
       def default_javascripts_path
         if (pp = top_level.project_path) && (dir = top_level.javascripts_dir)
           Compass.projectize(dir, pp)

--- a/lib/compass/exec/project_options_parser.rb
+++ b/lib/compass/exec/project_options_parser.rb
@@ -24,6 +24,10 @@ module Compass::Exec::ProjectOptionsParser
       self.options[:project_path] = project_path
     end
 
+    opts.on('--output-dir OUTPUT_DIR', "An override directory to output generated css files to.") do |output_dir|
+      self.options[:output_dir] = output_dir
+    end
+
     opts.on('--sass-dir SRC_DIR', "The source directory where you keep your sass stylesheets.") do |sass_dir|
       set_dir_or_path(:sass, sass_dir)
     end

--- a/lib/compass/exec/project_options_parser.rb
+++ b/lib/compass/exec/project_options_parser.rb
@@ -24,8 +24,8 @@ module Compass::Exec::ProjectOptionsParser
       self.options[:project_path] = project_path
     end
 
-    opts.on('--output-dir OUTPUT_DIR', "An override directory to output generated css files to.") do |output_dir|
-      self.options[:output_dir] = output_dir
+    opts.on('--output-dir OUTPUT_PATH', "An override directory to output generated files to.") do |output_path|
+      self.options[:output_path] = output_path
     end
 
     opts.on('--sass-dir SRC_DIR', "The source directory where you keep your sass stylesheets.") do |sass_dir|


### PR DESCRIPTION
Hi,

When using compass as part of a build system, eg. in grunt or yeoman, it is often preferable to generate files in a temporary place, but yet generate them as if they had been created in the source. This keeps the source directory clean. The option --output-dir gives compass the ability to create its css and reference any assets as if the css was being created in --css-dir, but instead of placing the file there, place it in output-dir.
