### PR TITLE
Adding ability to extend command line options with custom extensions

### DIFF
--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -183,7 +183,7 @@ Feature: Command Line
     Given ruby supports fork
     Given I am using the existing project in test/fixtures/stylesheets/compass
     When I run: compass compile
-    And I run in a separate process: compass watch 
+    And I run in a separate process: compass watch
     And I wait 3 seconds
     And I touch sass/layout.sass
     And I wait 2 seconds
@@ -204,7 +204,7 @@ Feature: Command Line
     When I run: compass config -p <property>
     Then I should see the following output: <value>
     And the command exits <exit>
-  
+
     Examples:
       | property        | value                    | exit     |
       | extensions_dir  | extensions               | normally |
@@ -213,7 +213,18 @@ Feature: Command Line
       | css_path        | $PROJECT_PATH/tmp        | normally |
       | sass_dir        | sass                     | normally |
       | sass_path       | $PROJECT_PATH/sass       | normally |
-      | foobar          | ERROR: configuration property 'foobar' does not exist | with a non-zero error code | 
+      | foobar          | ERROR: configuration property 'foobar' does not exist | with a non-zero error code |
+
+  Scenario: Creating a config with command_extensions
+    Given I should clean up the directory: config
+    When I run: compass config config/compass.rb --command-extensions=command-line-extension-test
+    Then a configuration file config/compass.rb is created
+    And the following configuration properties are set in config/compass.rb:
+      | property           | value                       |
+      | command_extensions | command-line-extension-test |
+    When I run: compass config -p command_extensions
+    Then I should see the following output: command-line-extension-test
+    And the command exits normally
 
   @validator
   Scenario: Validate the generated CSS

--- a/features/command_line.feature
+++ b/features/command_line.feature
@@ -226,6 +226,16 @@ Feature: Command Line
     Then I should see the following output: command-line-extension-test
     And the command exits normally
 
+  Scenario: Creating a config with multiple command_extensions
+    Given I should clean up the directory: config
+    When I run: compass config config/compass.rb --command-extensions command-line-extension-test1,command-line-extension-test2
+    Then a configuration file config/compass.rb is created
+    And the command_extensions property is set to ["command-line-extension-test1","command-line-extension-test2"] in config/compass.rb:
+    When I run: compass config -p command_extensions
+    Then I should see the following commands:
+      | command-line-extension-test1 | command-line-extension-test2 |
+    And the command exits normally
+
   @validator
   Scenario: Validate the generated CSS
     Given I am using the existing project in test/fixtures/stylesheets/valid

--- a/features/extensions.feature
+++ b/features/extensions.feature
@@ -13,6 +13,14 @@ Feature: Extensions
     Then the list of frameworks includes "testing"
 
   @listframeworks
+  Scenario: Extensions directory for stand_alone projects using a command-line extension
+    Given I am using the existing project in test/fixtures/stylesheets/compass
+    And the "extensions" directory exists
+    And and I have a fake command-line extension at extensions/compass-command-testing
+    When I run: compass frameworks
+    Then the list of frameworks includes "compass-command-testing"
+
+  @listframeworks
   Scenario: Shared extensions directory
     Given the "~/.compass/extensions" directory exists
     And and I have a fake extension at ~/.compass/extensions/testing

--- a/features/step_definitions/command_line_steps.rb
+++ b/features/step_definitions/command_line_steps.rb
@@ -14,7 +14,7 @@ Before do
   @cleanup_directories = []
   @original_working_directory = Dir.pwd
 end
- 
+
 After do
   Dir.chdir @original_working_directory
   @cleanup_directories.each do |dir|
@@ -66,7 +66,7 @@ When /^I run: compass ([^\s]+) ?(.+)?$/ do |command, args|
 end
 
 When /^I run in a separate process: compass ([^\s]+) ?(.+)?$/ do |command, args|
-  unless @other_process = fork 
+  unless @other_process = fork
     @last_result = ''
     @last_error = ''
     Signal.trap("HUP") do
@@ -113,7 +113,7 @@ end
 Then /^a directory ([^ ]+) is (not )?created$/ do |directory, negated|
   File.directory?(directory).should == !negated
 end
- 
+
 Then /an? \w+ file ([^ ]+) is (not )?removed/ do |filename, negated|
   File.exists?(filename).should == !!negated
 end
@@ -217,10 +217,19 @@ Then /^the list of commands should describe the ([^ ]+) command$/ do |command|
 end
 
 Then /^the following configuration properties are set in ([^ ]+):$/ do |config_file, table|
-  
+
   config = Compass::Configuration::FileData.new_from_file(config_file)
   table.hashes.each do |hash|
    config.send(hash['property']).should == hash['value']
+  end
+end
+
+Then /^the ([^\s]+) property is set to \["(.+)"\] in ([^\s]+):$/ do |prop, commands, config_file|
+  config = Compass::Configuration::FileData.new_from_file(config_file)
+  @last_command_list = commands.split('","')
+
+  @last_command_list.each_with_index do |command, index|
+    config.send(prop)[index].should == command
   end
 end
 
@@ -252,9 +261,12 @@ Then /^I should see the following "([^"]+)" commands:$/ do |kind, table|
   commands = @last_command_list.map{|c| c =~ /^\s+\* ([^ ]+)\s+- [A-Z].+$/; [$1]}
   table.diff!(commands)
 end
-     
 
-Then /^the image ([^ ]+) has a size of (\d+)x(\d+)$/ do |file, width, height| 
+Then /^I should see the following commands:$/ do |table|
+  table.diff!([@last_command_list])
+end
+
+Then /^the image ([^ ]+) has a size of (\d+)x(\d+)$/ do |file, width, height|
   # see http://snippets.dzone.com/posts/show/805
   size = File.open(file, "rb") {|io| io.read}[0x10..0x18].unpack('NN')
   size.should == [width.to_i, height.to_i]

--- a/features/step_definitions/extension_steps.rb
+++ b/features/step_definitions/extension_steps.rb
@@ -1,5 +1,6 @@
 Given /^the "([^\"]*)" directory exists$/ do |directory|
   directory.gsub!('~', ENV["HOME"]) if directory.include?('~/')
+  @cleanup_directories << directory
   FileUtils.mkdir_p directory
 end
 
@@ -16,6 +17,13 @@ Given /^and I have a fake extension at (.*)$/ do |directory|
       welcome_message "this is a fake welcome"
     }
   end
+end
+
+Given /^and I have a fake command\-line extension at (.*)$/ do |directory|
+  directory.gsub!('~', ENV["HOME"]) if directory.include?('~/')
+  FileUtils.mkdir_p File.join(directory, 'lib')
+  framework = directory.split('/').last
+  FileUtils.touch File.join(directory, 'lib', framework+'.rb')
 end
 
 Then /^the list of frameworks includes "([^\"]*)"$/ do |framework|

--- a/lib/compass/commands.rb
+++ b/lib/compass/commands.rb
@@ -3,10 +3,13 @@ end
 
 require 'compass/commands/registry'
 
-%w(base project_base default help list_frameworks 
+%w(base project_base default help list_frameworks
    update_project watch_project create_project clean_project extension_command
    imports installer_command print_version project_stats stamp_pattern
    sprite validate_project write_configuration interactive unpack_extension
+   load_command_extensions
 ).each do |lib|
   require "compass/commands/#{lib}"
 end
+
+Compass::Commands::CommandExtensionLoader.load_extensions_in_config

--- a/lib/compass/commands.rb
+++ b/lib/compass/commands.rb
@@ -13,3 +13,4 @@ require 'compass/commands/registry'
 end
 
 Compass::Commands::CommandExtensionLoader.load_extensions_in_config
+Compass.discover_extensions!

--- a/lib/compass/commands/load_command_extensions.rb
+++ b/lib/compass/commands/load_command_extensions.rb
@@ -1,0 +1,38 @@
+module Compass
+  module Commands
+    class CommandExtensionLoader
+
+      def self.load_extensions_in_config
+        Compass.add_project_configuration(nil, :defaults => Compass.configuration_for({}, "cli_defaults"))
+        command_extensions = Compass.configuration.command_extensions
+
+        if command_extensions.is_a?(Array)
+          command_extensions.each do |command|
+            load_extension(get_extension_name(command))
+          end
+        else
+          load_extension(get_extension_name(command_extensions))
+        end
+      end
+
+      private
+
+      def self.get_extension_name(name)
+        if name.start_with?('compass-')
+          return name
+        else
+          return 'compass-' + name
+        end
+      end
+
+      def self.load_extension(gem_name)
+        require gem_name
+        rescue LoadError => e
+          puts e.message
+          puts "\nPlease either install it:\n\nsudo gem install #{gem_name}\n\nor remove the reference to it on the command_extensions line of your config.rb file\n\n"
+          raise Compass::MissingDependency
+      end
+
+    end
+  end
+end

--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -29,6 +29,7 @@ module Compass
       :environment,
       :relative_assets,
       :additional_import_paths,
+      :command_extensions,
       :sass_options,
       attributes_for_directory(:cache, nil),
       :cache,

--- a/lib/compass/configuration/defaults.rb
+++ b/lib/compass/configuration/defaults.rb
@@ -103,7 +103,7 @@ module Compass
       def default_http_images_dir
         top_level.images_dir
       end
-      
+
       def default_sprite_load_path
         [top_level.images_path]
       end
@@ -144,6 +144,10 @@ module Compass
         http_root_relative top_level.http_javascripts_dir
       end
 
+      def default_command_extensions
+        []
+      end
+
       def default_cache
         true
       end
@@ -151,15 +155,15 @@ module Compass
       def default_preferred_syntax
         :scss
       end
-      
+
       def default_sprite_engine
         :chunky_png
       end
-      
+
       def default_chunky_png_options
         {:compression => Zlib::BEST_COMPRESSION}
       end
-      
+
       # helper functions
 
       def http_join(*segments)

--- a/lib/compass/configuration/serialization.rb
+++ b/lib/compass/configuration/serialization.rb
@@ -73,7 +73,12 @@ module Compass
         if value.respond_to?(:serialize_to_config)
           value.serialize_to_config(prop) + "\n"
         else
-          %Q(#{prop} = #{value.inspect}\n)
+          if value.respond_to?('include?') && value.include?(",")
+            value = '["' + value.split(',').join('","') + '"]'
+            %Q(#{prop} = #{value}\n)
+          else
+            %Q(#{prop} = #{value.inspect}\n)
+          end
         end
       end
 

--- a/lib/compass/exec/project_options_parser.rb
+++ b/lib/compass/exec/project_options_parser.rb
@@ -70,7 +70,7 @@ module Compass::Exec::ProjectOptionsParser
       self.options[:generated_images_path] = generated_images_path
     end
 
-    opts.on('--command-extensions COMMANDS', 'Compass command line extensions to include.') do |command_extensions|
+    opts.on('--command-extensions COMMAND1,COMMAND2', 'Compass command line extensions to include.') do |command_extensions|
       self.options[:command_extensions] = command_extensions
     end
   end

--- a/lib/compass/exec/project_options_parser.rb
+++ b/lib/compass/exec/project_options_parser.rb
@@ -69,6 +69,10 @@ module Compass::Exec::ProjectOptionsParser
     opts.on('--generated-images-path GENERATED_IMAGES_PATH', 'The path where you generate your images') do |generated_images_path|
       self.options[:generated_images_path] = generated_images_path
     end
+
+    opts.on('--command-extensions COMMANDS', 'Compass command line extensions to include.') do |command_extensions|
+      self.options[:command_extensions] = command_extensions
+    end
   end
 
 end

--- a/test/units/command_line_test.rb
+++ b/test/units/command_line_test.rb
@@ -55,4 +55,12 @@ class CommandLineTest < Test::Unit::TestCase
     end
   end
 
+  def test_command_line_extensions
+    within_tmp_directory do
+      # create config with command_extensions
+      compass "config", "config.rb", "--command-extensions=command-line-extension-test"
+      assert_action_performed    :create, "config.rb"
+    end
+  end
+
 end

--- a/test/units/configuration_test.rb
+++ b/test/units/configuration_test.rb
@@ -7,7 +7,7 @@ class ConfigurationTest < Test::Unit::TestCase
   setup do
     Compass.reset_configuration!
   end
-  
+
   after do
     Compass.reset_configuration!
   end
@@ -18,22 +18,22 @@ class ConfigurationTest < Test::Unit::TestCase
       # Require any additional compass plugins here.
 
       project_type = :stand_alone
-      
+
       http_path = "/"
       css_dir = "css"
       sass_dir = "sass"
       images_dir = "img"
       javascripts_dir = "js"
-      
+
       output_style = :nested
-      
+
       # To enable relative paths to assets via compass helper functions. Uncomment:
       # relative_assets = true
-      
+
       # To disable debugging comments that display the original location of your selectors. Uncomment:
       # line_comments = false
-      
-      
+
+
       # If you prefer the indented syntax, you might want to regenerate this
       # project again passing --syntax sass, or you can uncomment this:
       # preferred_syntax = :sass
@@ -392,6 +392,66 @@ EXPECTED
     assert_equal "extensions", Compass.configuration.extensions_dir
   end
 
+  def test_command_extensions_array
+    # Add an array of multiple command-line extensions to compass.
+    contents = StringIO.new(<<-CONFIG)
+      command_extensions = ["foo", "bar"]
+    CONFIG
+
+    Compass.add_configuration(contents, "test_command_extensions_array")
+
+    assert_equal ["foo", "bar"], Compass.configuration.command_extensions
+
+    expected_serialization = <<EXPECTED
+# Require any additional compass plugins here.
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+
+# You can select your preferred output style here (can be overridden via the command line):
+# output_style = :expanded or :nested or :compact or :compressed
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+# relative_assets = true
+command_extensions = ["foo", "bar"]
+
+# To disable debugging comments that display the original location of your selectors. Uncomment:
+# line_comments = false
+
+EXPECTED
+    assert_correct(expected_serialization, Compass.configuration.serialize)
+  end
+
+  def test_command_extensions_string
+    # Add a single command-line extensions to compass.
+    contents = StringIO.new(<<-CONFIG)
+      command_extensions = "foo"
+    CONFIG
+
+    Compass.add_configuration(contents, "test_command_extensions_string")
+
+    assert_equal "foo", Compass.configuration.command_extensions
+
+    expected_serialization = <<EXPECTED
+# Require any additional compass plugins here.
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+
+# You can select your preferred output style here (can be overridden via the command line):
+# output_style = :expanded or :nested or :compact or :compressed
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+# relative_assets = true
+command_extensions = "foo"
+
+# To disable debugging comments that display the original location of your selectors. Uncomment:
+# line_comments = false
+
+EXPECTED
+    assert_correct(expected_serialization, Compass.configuration.serialize)
+  end
+
   def test_custom_configuration_properties
     # Add a configuration property to compass.
     Compass::Configuration.add_configuration_property(:foobar, "this is a foobar") do
@@ -448,5 +508,5 @@ EXPECTED
       end
     end.compact
   end
-  
+
 end


### PR DESCRIPTION
Here is my proposal to fix issue #1053

This will allow anyone to include custom command line extension for Compass. In order for a command line extension to work, it must be available as a gem that is prefixed with "compass-". Users can then include that in their projects by adding a command_extensions property to their config.rb file, such as:

``` ruby
command_extensions = ["csslint"]
```

The above example would include the [compass-csslint](https://github.com/Comcast/compass-csslint) command line extension.

command_extensions is intended to take an array of strings, although I did also add support for it to be just a string if only 1 extension is desired to be included. The strings can include the "compass-" prefix as well:

``` ruby
command_extensions = ["compass-csslint"]
```
