### PR TITLE
Abstract digest class

### DIFF
--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -40,6 +40,7 @@ module Compass
       :preferred_syntax,
       :disable_warnings,
       :sprite_engine,
+      :digest_class,
       :chunky_png_options
     ].flatten
 

--- a/lib/compass/configuration/defaults.rb
+++ b/lib/compass/configuration/defaults.rb
@@ -156,6 +156,10 @@ module Compass
         :chunky_png
       end
       
+      def default_digest_class
+        Digest::MD5
+      end
+
       def default_chunky_png_options
         {:compression => Zlib::BEST_COMPRESSION}
       end

--- a/lib/compass/sass_extensions/sprites/image.rb
+++ b/lib/compass/sass_extensions/sprites/image.rb
@@ -97,9 +97,9 @@ module Compass
           @spacing ||= (get_var_file("spacing") || options.get_var("spacing") || Sass::Script::Number.new(0, ['px'])).value
         end
 
-        # MD5 hash of this file
+        # Digest/hash of this file
         def digest
-          Digest::MD5.file(file).hexdigest
+          Compass.configuration.digest_class.file(file).hexdigest
         end
         
         # mtime of this file

--- a/lib/compass/sass_extensions/sprites/sprite_methods.rb
+++ b/lib/compass/sass_extensions/sprites/sprite_methods.rb
@@ -78,7 +78,7 @@ module Compass
         # Returns the uniqueness hash for this sprite object
         def uniqueness_hash
           @uniqueness_hash ||= begin
-            sum = Digest::MD5.new
+            sum = Compass.configuration.digest_class.new
             sum << SPRITE_VERSION
             sum << path
             sum << layout


### PR DESCRIPTION
When using compass to compile sprites, we have run into an issue where Digest::MD5 is not an acceptable digest algorithm -- specifically for (Linux) hosts running in FIPS-enabled mode.  As such, this proposed change is what we're using to abstract the digest class used.  The default is Digest::MD5, but in our application we override it with Digest::SHA2 in our compass.config.

I'm not sure what tests I can/should create.
