### PR TITLE
Flexbox mixin adjustments

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -231,25 +231,25 @@ $flex-legacy-orient: true !default;
 
 // Distributing extra space along the "cross axis"
 // $value: flex-start | flex-end | center | space-between | space-around | stretch
-@mixin align-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
-	@if $legacy and not $wrap {
-		@include legacy-align-content($value);
-	}
+@mixin align-content($value: flex-start) {
+	// There is no @box version of this property
 
 	@include experimental(flex-line-pack, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(align-content, $value, $flex-support...);
 }
 
-@mixin legacy-align-content($value: flex-start) {
-	@include experimental(box-align, flex-translate-value($value, box), $box-support...);
-}
-
 // Align items along the "cross axis"
 // $value: flex-start | flex-end | center | baseline | stretch
-@mixin align-items($value: stretch) { // the flex container
-	// There is no @box version of this property
+@mixin align-items($value: stretch, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) { // the flex container
+	@if $legacy and not $wrap {
+		@include legacy-align-items($value);
+	}
 	@include experimental(flex-align, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(align-items, $value, $flex-support...);
+}
+
+@mixin legacy-align-items($value: flex-start) {
+	@include experimental(box-align, flex-translate-value($value, box), $box-support...);
 }
 
 // @doc off

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -17,11 +17,14 @@ $flex-legacy-enabled: false !default;
 // (this includes suppressing the automatic emittion of @box properties)
 $flex-wrap-required : false !default;
 
-// The modern `flex-direction` property corresponds to two properties in the @box spec.  If
-// this variable is set to false, then `box-direction: normal` will not be emitted when the 
-// `legacy-flex-direction` mixin is invoked.  If either of the reverse values are used, 
-// `box-direction: reverse` will always be emitted.
-$box-direction-normal: true !default;
+// The modern `flex-direction` property corresponds to two properties in the @box spec.  This 
+// variable allows you to suppress it from being emitted when the `legacy-flex-direction` mixin
+// is invoked:
+//     false  : always emit
+//     true   : always suppress
+//     normal : suppress the `normal` direction
+//     reverse: suppress the `reverse` direction
+$suppress-box-direction: false !default;
 
 // @flex
 // September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
@@ -31,7 +34,7 @@ $box-direction-normal: true !default;
 // finally added
 // Chrome 21 (prefixed)
 // Opera 12.1 (unprefixed)
-// Firefox 20 (unprefixed)
+// Firefox 22 (unprefixed)
 $flex-support: not -moz, -webkit, not -o, not -ms, not -khtml !default;
 
 // @flexbox
@@ -121,7 +124,7 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 // ====================================================================================================
 
 // $value: <'flex-direction'> || <'flex-wrap'>
-@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $normal: $box-direction-normal) {
+@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $suppress: $suppress-box-direction) {
 	@if $legacy and not $wrap {
 		@include legacy-flex-flow($value);
 	}
@@ -129,9 +132,9 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 	@include experimental(flex-flow, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-flow($value: row nowrap, $normal: $box-direction-normal) {
+@mixin legacy-flex-flow($value: row nowrap, $suppress: $suppress-box-direction) {
 	@if length($value) > 1 { // @box version doesn't have a shorthand
-		@include legacy-flex-direction(nth($value, 1), $normal);
+		@include legacy-flex-direction(nth($value, 1), $suppress);
 		@include legacy-flex-wrap(nth($value, 2));
 	} @else {
 		$value: unquote($value);
@@ -146,19 +149,20 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 // ----------------------------------------------------------------------
 
 // $value: row | row-reverse | column | column-reverse
-@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $normal: $box-direction-normal) {
+@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $suppress: $suppress-box-direction) {
 	@if $legacy and not $wrap {
-		@include legacy-flex-direction($value, $normal);
+		@include legacy-flex-direction($value, $suppress);
 	}
 	
 	@include experimental(flex-direction, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-direction($value: row, $normal: $box-direction-normal) {
+@mixin legacy-flex-direction($value: row, $suppress: $suppress-box-direction) {
 	$value: unquote($value);
+	$direction: if($value == row-reverse or $value == column-reverse, reverse, normal);
 	@include experimental(box-orient, if($value == row or $value == row-reverse, horizontal, vertical), $box-support...);
-	@if $value == row-reverse or $value == column-reverse or $normal {
-		@include experimental(box-direction, if($value == row-reverse or $value == column-reverse, reverse, normal), $box-support...);
+	@if not $suppress or $suppress != $direction {
+		@include experimental(box-direction, $direction, $box-support...);
 	}
 }
 

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -1,5 +1,6 @@
 @import "shared";
 
+
 // NOTE:
 // -----
 // All mixins for the @box spec have been written assuming they'll be fed property values that
@@ -262,25 +263,25 @@ $flex-legacy-orient: true !default;
 @mixin flex($value: 0 1 auto, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	$value: unquote($value);
 	@if $legacy and unitless(nth($value, 1)) {
-		// @box version does not have a shorthand, see `legacy-flex`
-		@include legacy-flex(nth($value, 1));
+		@include legacy-flex($value);
 	}
 
 	@include experimental(flex, $value, flex-support-common()...);
 }
 
-// $value: Integer
-@mixin flex-grow($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
-	@if $legacy and not $wrap {
-		@include legacy-flex($value);
+@mixin legacy-flex($value: 0) {
+	$value: nth($value, 1);
+	@if not unitless($value) {
+		@warn 'The legacy flex property `box-flex` requires an Integer (eg. 1)';
 	}
-
-	// There is no @flexbox version of this property
-	@include experimental(flex-grow, $value, $flex-support...);
+	@include experimental(box-flex, $value, $box-support...);
 }
 
-@mixin legacy-flex($value: 0) {
-	@include experimental(box-flex, $value, $box-support...);
+// $value: Integer
+@mixin flex-grow($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	// There is no @box version of this property
+	// There is no @flexbox version of this property
+	@include experimental(flex-grow, $value, $flex-support...);
 }
 
 // $value: Integer

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -17,14 +17,22 @@ $flex-legacy-enabled: false !default;
 // (this includes suppressing the automatic emittion of @box properties)
 $flex-wrap-required : false !default;
 
-// The modern `flex-direction` property corresponds to two properties in the @box spec.  This 
-// variable allows you to suppress it from being emitted when the `legacy-flex-direction` mixin
-// is invoked:
+// The modern `flex-direction` property corresponds to two properties in the @box spec and the
+// `legacy-flex-direction` mixin will emit both by default.
+
+//  This variable controls the emition of the `box-direction` property:
 //     true   : always emit
 //     false  : always suppress
 //     normal : only emit if the direction is `normal`
 //     reverse: only emit if the direction is `reverse`
 $flex-legacy-direction: true !default;
+
+//  This variable controls the emition of the `box-orient` property:
+//     true                : always emit
+//     false               : always suppress
+//     horizontal or row   : only emit if the orient is `horizontal`
+//     vertical or column  : only emit if the orient is `vertical`
+$flex-legacy-orient: true !default;
 
 // @flex
 // September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
@@ -124,17 +132,17 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 // ====================================================================================================
 
 // $value: <'flex-direction'> || <'flex-wrap'>
-@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $direction: $flex-legacy-direction) {
+@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
 	@if $legacy and not $wrap {
-		@include legacy-flex-flow($value);
+		@include legacy-flex-flow($value, $orient, $direction);
 	}
 	
 	@include experimental(flex-flow, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-flow($value: row nowrap, $direction: $flex-legacy-direction) {
+@mixin legacy-flex-flow($value: row nowrap, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
 	@if length($value) > 1 { // @box version doesn't have a shorthand
-		@include legacy-flex-direction(nth($value, 1), $direction);
+		@include legacy-flex-direction(nth($value, 1), $orient, $direction);
 		@include legacy-flex-wrap(nth($value, 2));
 	} @else {
 		$value: unquote($value);
@@ -149,18 +157,23 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 // ----------------------------------------------------------------------
 
 // $value: row | row-reverse | column | column-reverse
-@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $direction: $flex-legacy-direction) {
+@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
 	@if $legacy and not $wrap {
-		@include legacy-flex-direction($value, $direction);
+		@include legacy-flex-direction($value, $orient, $direction);
 	}
 	
 	@include experimental(flex-direction, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-direction($value: row, $direction: $flex-legacy-direction) {
+@mixin legacy-flex-direction($value: row, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
 	$value: unquote($value);
-	$translated-direction: if($value == row-reverse or $value == column-reverse, reverse, normal);
-	@include experimental(box-orient, if($value == row or $value == row-reverse, horizontal, vertical), $box-support...);
+	$translated-orient: if($value == row or $value == row-reverse, row, column);
+	$translated-direction: if($value == row or $value == column, normal, reverse);
+
+	@if $orient == true or $translated-orient == $orient {
+		@include experimental(box-orient, if($translated-orient == row or $translated-orient == horizontal, horizontal, vertical), $box-support...);
+	}
+
 	@if $direction == true or $translated-direction == $direction {
 		@include experimental(box-direction, $translated-direction, $box-support...);
 	}

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -1,6 +1,5 @@
 @import "shared";
 
-
 // NOTE:
 // -----
 // All mixins for the @box spec have been written assuming they'll be fed property values that
@@ -18,7 +17,8 @@
 // finally added
 // Chrome 21 (prefixed)
 // Opera 12.1 (unprefixed)
-// Firefox 20 (unprefixed)
+// Firefox 22 (unprefixed)
+// Internet Explorer 11 (unprefixed)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
@@ -33,7 +33,7 @@ $flex-wrap-required : false !default;
 // @private Flexbox
 // ----------------
 // March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
-// Chrome 17 (prefixed)
+// Chrome 17-? (prefixed)
 // Internet Explorer 10 (prefixed)
 
 // @private css3-feature-support variables must always include a list of five boolean values
@@ -46,7 +46,7 @@ $flexbox-support: not -moz, not -webkit, not -o, -ms, not -khtml, not standard !
 // NOTE: no browser that implements this spec is known to support `box-lines: multiple`
 // Chrome 4? (prefixed)
 // Safari 3.1 (prefixed)
-// Firefox <20 (prefixed)
+// Firefox 2.0? (prefixed)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -38,7 +38,7 @@ $flex-wrap-required : false !default;
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
-$flexbox-support: not -moz, -webkit, not -o, -ms, not -khtml, not standard !default;
+$flexbox-support: not -moz, not -webkit, not -o, -ms, not -khtml, not standard !default;
 
 // @private Box
 // ------------

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -16,7 +16,7 @@
 // argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when support is
 // finally added
 // Chrome 21 (prefixed)
-// Opera 12.x (unprefixed)
+// Opera 12.1-12.16 (unprefixed)
 // Opera 15 (webkit prefix)
 // Firefox 22 (unprefixed)
 // Internet Explorer 11 (unprefixed)

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -229,11 +229,14 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 @mixin flex($value: 0 1 auto, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	$value: unquote($value);
 	@if $legacy and unitless(nth($value, 1)) {
-		// @box version does not have a shorthand, see `legacy-flex-grow`
-		@include legacy-flex-grow(nth($value, 1));
+		@include legacy-flex(nth($value, 1));
 	}
 	
 	@include experimental(flex, $value, flex-support-common()...);
+}
+
+@mixin legacy-flex($value: 0) {
+	@include experimental(box-flex, $value, $box-support...);
 }
 
 // ----------------------------------------------------------------------
@@ -246,10 +249,6 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 	
 	// There is no @flexbox version of this property
 	@include experimental(flex-grow, $value, $flex-support...);
-}
-
-@mixin legacy-flex-grow($value: 0) {
-	@include experimental(box-flex, $value, $box-support...);
 }
 
 // ----------------------------------------------------------------------

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -15,12 +15,14 @@
 // is wrapped in a `@supports (flex-wrap: wrap)` block (when $flex-wrap-required or the $wrap
 // argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when support is
 // finally added
-// Chrome 21 (prefixed)
+// Chrome 21 (-webkit-)
+// Safari 7.0 (-webkit-)
+// iOS 7.0 (-webkit-)
+// Blackberry 10 (-webkit-)
+// Opera 15 (-webkit-)
 // Opera 12.1-12.16 (unprefixed)
-// Opera 15 (webkit prefix)
 // Firefox 22 (unprefixed)
 // Internet Explorer 11 (unprefixed)
-// Safari 6.1 (prefixed)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
@@ -35,8 +37,8 @@ $flex-wrap-required : false !default;
 // @private Flexbox
 // ----------------
 // March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
-// Chrome 17-? (prefixed)
-// Internet Explorer 10 (prefixed)
+// Chrome 17-? (-webkit-), unknown when support for this stopped
+// Internet Explorer 10 (-webkit-)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
@@ -46,9 +48,13 @@ $flexbox-support: not -moz, not -webkit, not -o, -ms, not -khtml, not standard !
 // ------------
 // July 2009 Working Draft (http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/)
 // NOTE: no browser that implements this spec is known to support `box-lines: multiple`
-// Chrome 4? (prefixed)
-// Safari 3.1 (prefixed)
-// Firefox 2.0? (prefixed)
+// Chrome 4? (-webkit-)
+// Safari 3.1 (-webkit-)
+// iOS 3.2 (-webkit-)
+// Android 2.1 (-webkit-)
+// Blackberry 7 (-webkit-)
+// Opera 12.?, 15 (-webkit-)
+// Firefox 2.0? (-moz-)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
@@ -109,6 +115,14 @@ $flex-legacy-orient: true !default;
 		$common: append($common, nth($flex-support, $i) or nth($flexbox-support, $i), comma);
 	}
 	@return $common;
+}
+
+@function generate-box-properties() {
+	@return $box-support != (false, false, false, false, false, false);
+}
+
+@function generate-flexbox-properties() {
+	@return $flexbox-support != (false, false, false, false, false, false);
 }
 
 // @doc off
@@ -213,6 +227,9 @@ $flex-legacy-orient: true !default;
 
 @mixin legacy-flex-wrap($value: nowrap) {
 	// NOTE: @box has no equivalent of wrap-reverse
+	@if $value != nowrap {
+		@warn "No 2009 Flexbox (@box) implementation supports wrapping";
+	}
 	@include experimental(box-lines, if($value == nowrap, single, multiple), $box-support...);
 }
 
@@ -280,7 +297,7 @@ $flex-legacy-orient: true !default;
 }
 
 // $value: Integer
-@mixin flex-grow($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+@mixin flex-grow($value: 0) {
 	// There is no @box version of this property
 	// There is no @flexbox version of this property
 	@include experimental(flex-grow, $value, $flex-support...);

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -35,13 +35,13 @@ $flex-legacy-direction: true !default;
 // Chrome 21 (prefixed)
 // Opera 12.1 (unprefixed)
 // Firefox 22 (unprefixed)
-$flex-support: not -moz, -webkit, not -o, not -ms, not -khtml !default;
+$flex-support: not -moz, -webkit, not -ms, not -o, not -khtml !default;
 
 // @flexbox
 // March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
 // Chrome 17 (prefixed)
 // Internet Explorer 10 (prefixed)
-$flexbox-support: not -moz, -webkit, not -o, -ms, not -khtml, not standard !default;
+$flexbox-support: not -moz, -webkit, -ms, not -o, not -khtml, not standard !default;
 
 // @box
 // July 2009 Working Draft (http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/)
@@ -49,7 +49,7 @@ $flexbox-support: not -moz, -webkit, not -o, -ms, not -khtml, not standard !defa
 // Chrome 4? (prefixed)
 // Safari 3.1 (prefixed)
 // Firefox <20 (prefixed)
-$box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
+$box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 
 // ====================================================================================================
 //                                                                       | Common

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -1,21 +1,59 @@
 @import "shared";
 
 // NOTE:
+// -----
 // All mixins for the @box spec have been written assuming they'll be fed property values that
 // correspond to the standard spec.  Some mixins can be fed values from the @box spec, but don't
 // rely on it.  The `legacy-order` mixin will increment the value fed to it because the @box
 // `box-ordinal-group` property begins indexing at 1, while the modern `order` property begins
 // indexing at 0.
 
-// if `true`, the @box properties will be emitted as part of the normal mixin call
-// (if this is false, you're still free to explicitly call the legacy mixins yourself)
-$flex-legacy-enabled: false !default;
+// @private Flex
+// -------------
+// September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
+// NOTE: FF did not support wrapping until version ??.  Because the `display: flex` property
+// is wrapped in a `@supports (flex-wrap: wrap)` block (when $flex-wrap-required or the $wrap
+// argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when support is
+// finally added
+// Chrome 21 (prefixed)
+// Opera 12.1 (unprefixed)
+// Firefox 20 (unprefixed)
 
-// if `true`, `$flex-legacy-enabled` is treated as false and an `@supports` block is added to 
+// @private css3-feature-support variables must always include a list of five boolean values
+// representing in order: -moz, -webkit, -o, -ms, -khtml.
+$flex-support: not -moz, -webkit, not -o, not -ms, not -khtml !default;
+
+// if `true`, `$flex-legacy-enabled` is treated as false and an `@supports` block is added to
 // the display property to hide the standard value from versions of Firefox that support the
 // unprefixed properties, but do not support wrapping
 // (this includes suppressing the automatic emittion of @box properties)
 $flex-wrap-required : false !default;
+
+// @private Flexbox
+// ----------------
+// March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
+// Chrome 17 (prefixed)
+// Internet Explorer 10 (prefixed)
+
+// @private css3-feature-support variables must always include a list of five boolean values
+// representing in order: -moz, -webkit, -o, -ms, -khtml.
+$flexbox-support: not -moz, -webkit, not -o, -ms, not -khtml, not standard !default;
+
+// @private Box
+// ------------
+// July 2009 Working Draft (http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/)
+// NOTE: no browser that implements this spec is known to support `box-lines: multiple`
+// Chrome 4? (prefixed)
+// Safari 3.1 (prefixed)
+// Firefox <20 (prefixed)
+
+// @private css3-feature-support variables must always include a list of five boolean values
+// representing in order: -moz, -webkit, -o, -ms, -khtml.
+$box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
+
+// If `true`, the @box properties will be emitted as part of the normal mixin call
+// (if this is false, you're still free to explicitly call the legacy mixins yourself)
+$flex-legacy-enabled: false !default;
 
 // The modern `flex-direction` property corresponds to two properties in the @box spec and the
 // `legacy-flex-direction` mixin will emit both by default.
@@ -34,34 +72,12 @@ $flex-legacy-direction: true !default;
 //     vertical  : only emit if the orient is `vertical`
 $flex-legacy-orient: true !default;
 
-// @flex
-// September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
-// NOTE: FF did not support wrapping until version ??.  Because the `display: flex` property
-// is wrapped in a `@supports (flex-wrap: wrap)` block (when $flex-wrap-required or the $wrap
-// argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when support is
-// finally added
-// Chrome 21 (prefixed)
-// Opera 12.1 (unprefixed)
-// Firefox 22 (unprefixed)
-$flex-support: not -moz, -webkit, not -ms, not -o, not -khtml !default;
+// @doc off
 
-// @flexbox
-// March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
-// Chrome 17 (prefixed)
-// Internet Explorer 10 (prefixed)
-$flexbox-support: not -moz, -webkit, -ms, not -o, not -khtml, not standard !default;
+// Common Mixins
+// =============
 
-// @box
-// July 2009 Working Draft (http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/)
-// NOTE: no browser that implements this spec is known to support `box-lines: multiple`
-// Chrome 4? (prefixed)
-// Safari 3.1 (prefixed)
-// Firefox <20 (prefixed)
-$box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
-
-// ====================================================================================================
-//                                                                       | Common
-// ====================================================================================================
+// @doc on
 
 // function for converting a value from the standard specification to one that is comparable from
 // an older specification
@@ -92,18 +108,21 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@return $common;
 }
 
-// ====================================================================================================
-//                                                                       | Display Property
-// ====================================================================================================
+// @doc off
+
+// Display Property
+// ================
+
+// @doc on
 
 // $type: flex | inline-flex
 @mixin display-flex($type: flex, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	@if $legacy and not $wrap {
 		@include legacy-display-flex($type);
 	}
-	
+
 	@include experimental-value(display, flex-translate-value($type, flexbox), $flexbox-support...);
-	
+
 	// if `$wrap` is true, then we need to suppress official support as generated by the `experimental()`
 	// mixin so that we can insert it inside an `@supports` block
 	$flex-support-standard: true;
@@ -115,7 +134,7 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	}
 	$flex-support-list: append($flex-support-list, if($wrap, false, $flex-support-standard));
 	@include experimental-value(display, $type, $flex-support-list...);
-	
+
 	@if $wrap and $flex-support-standard {
 		@supports (flex-wrap: wrap) {
 			display: $type;
@@ -127,9 +146,12 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@include experimental-value(display, flex-translate-value($type, box), $box-support...);
 }
 
-// ====================================================================================================
-//                                                                       | Flex Container Properties
-// ====================================================================================================
+// @doc off
+
+// Flex Container Properties
+// =========================
+
+// @doc on
 
 // $value: <'flex-direction'> || <'flex-wrap'>
 @mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
@@ -154,8 +176,6 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	}
 }
 
-// ----------------------------------------------------------------------
-
 // $value: row | row-reverse | column | column-reverse
 @mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
 	@if $legacy and not $wrap {
@@ -179,14 +199,12 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	}
 }
 
-// ----------------------------------------------------------------------
-
 // $value: nowrap | wrap | wrap-reverse
 @mixin flex-wrap($value: nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	@if $legacy and not $wrap {
 		@include legacy-flex-wrap($value);
 	}
-	
+
 	@include experimental(flex-wrap, $value, flex-support-common()...);
 }
 
@@ -195,15 +213,13 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@include experimental(box-lines, if($value == nowrap, single, multiple), $box-support...);
 }
 
-// ----------------------------------------------------------------------
-
 // Distributing extra space along the "main axis"
 // $value: flex-start | flex-end | center | space-between | space-around
 @mixin justify-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	@if $legacy and not $wrap {
 		@include legacy-justify-content($value);
 	}
-	
+
 	@include experimental(flex-pack, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(justify-content, $value, $flex-support...);
 }
@@ -212,15 +228,13 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@include experimental(box-pack, flex-translate-value($value, box), $box-support...);
 }
 
-// ----------------------------------------------------------------------
-
 // Distributing extra space along the "cross axis"
 // $value: flex-start | flex-end | center | space-between | space-around | stretch
 @mixin align-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	@if $legacy and not $wrap {
 		@include legacy-align-content($value);
 	}
-	
+
 	@include experimental(flex-line-pack, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(align-content, $value, $flex-support...);
 }
@@ -228,8 +242,6 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 @mixin legacy-align-content($value: flex-start) {
 	@include experimental(box-align, flex-translate-value($value, box), $box-support...);
 }
-
-// ----------------------------------------------------------------------
 
 // Align items along the "cross axis"
 // $value: flex-start | flex-end | center | baseline | stretch
@@ -239,37 +251,37 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@include experimental(align-items, $value, $flex-support...);
 }
 
-// ====================================================================================================
-//                                                                       | Flex Item Properties
-// ====================================================================================================
+// @doc off
+
+// Flex Item Properties
+// ====================
+
+// @doc on
 
 // $value: none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]
 @mixin flex($value: 0 1 auto, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	$value: unquote($value);
 	@if $legacy and unitless(nth($value, 1)) {
+		// @box version does not have a shorthand, see `legacy-flex`
 		@include legacy-flex(nth($value, 1));
 	}
-	
+
 	@include experimental(flex, $value, flex-support-common()...);
+}
+
+// $value: Integer
+@mixin flex-grow($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+	@if $legacy and not $wrap {
+		@include legacy-flex($value);
+	}
+
+	// There is no @flexbox version of this property
+	@include experimental(flex-grow, $value, $flex-support...);
 }
 
 @mixin legacy-flex($value: 0) {
 	@include experimental(box-flex, $value, $box-support...);
 }
-
-// ----------------------------------------------------------------------
-
-// $value: Integer
-@mixin flex-grow($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
-	@if $legacy and not $wrap {
-		@include legacy-flex-grow($value);
-	}
-	
-	// There is no @flexbox version of this property
-	@include experimental(flex-grow, $value, $flex-support...);
-}
-
-// ----------------------------------------------------------------------
 
 // $value: Integer
 @mixin flex-shrink($value: 1) {
@@ -278,16 +290,12 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@include experimental(flex-shrink, $value, $flex-support...);
 }
 
-// ----------------------------------------------------------------------
-
 // $value: united number (eg: 100px)
 @mixin flex-basis($value: auto) {
 	// There is no @box version of this property
 	// There is no @flexbox version of this property
 	@include experimental(flex-basis, $value, $flex-support...);
 }
-
-// ----------------------------------------------------------------------
 
 // Align items along the "cross axis" -- overrides `align-items` value on individual items
 // $value: auto | flex-start | flex-end | center | baseline | stretch
@@ -297,14 +305,12 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 	@include experimental(align-self, $value, $flex-support...);
 }
 
-// ----------------------------------------------------------------------
-
 // $value: Integer
 @mixin order($value: 0, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
 	@if $legacy and not $wrap {
 		@include legacy-order($value);
 	}
-	
+
 	@include experimental(flex-order, $value, $flexbox-support...);
 	@include experimental(order, $value, $flex-support...);
 }

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -28,10 +28,10 @@ $flex-wrap-required : false !default;
 $flex-legacy-direction: true !default;
 
 //  This variable controls the emition of the `box-orient` property:
-//     true                : always emit
-//     false               : always suppress
-//     horizontal or row   : only emit if the orient is `horizontal`
-//     vertical or column  : only emit if the orient is `vertical`
+//     true      : always emit
+//     false     : always suppress
+//     horizontal: only emit if the orient is `horizontal`
+//     vertical  : only emit if the orient is `vertical`
 $flex-legacy-orient: true !default;
 
 // @flex
@@ -167,11 +167,11 @@ $box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
 
 @mixin legacy-flex-direction($value: row, $orient: $flex-legacy-orient, $direction: $flex-legacy-direction) {
 	$value: unquote($value);
-	$translated-orient: if($value == row or $value == row-reverse, row, column);
+	$translated-orient: if($value == row or $value == row-reverse, horizontal, vertical);
 	$translated-direction: if($value == row or $value == column, normal, reverse);
 
 	@if $orient == true or $translated-orient == $orient {
-		@include experimental(box-orient, if($translated-orient == row or $translated-orient == horizontal, horizontal, vertical), $box-support...);
+		@include experimental(box-orient, $translated-orient, $box-support...);
 	}
 
 	@if $direction == true or $translated-direction == $direction {

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -17,9 +17,10 @@ $flex-legacy-enabled: false !default;
 // (this includes suppressing the automatic emittion of @box properties)
 $flex-wrap-required : false !default;
 
-// The modern `flex-direction` property corresponds to two properties in the @box spec.  If this
-// variable is set to false, then `box-direction: normal` will not be emitted.  If either of the 
-// reverse values are used, `box-direction: reverse` will always be emitted.
+// The modern `flex-direction` property corresponds to two properties in the @box spec.  If
+// this variable is set to false, then `box-direction: normal` will not be emitted when the 
+// `legacy-flex-direction` mixin is invoked.  If either of the reverse values are used, 
+// `box-direction: reverse` will always be emitted.
 $box-direction-normal: true !default;
 
 // @flex

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -16,7 +16,8 @@
 // argument to the `display-flex` mixin is set to `true`), it will Just Work(TM) when support is
 // finally added
 // Chrome 21 (prefixed)
-// Opera 12.1 (unprefixed)
+// Opera 12.x (unprefixed)
+// Opera 15 (webkit prefix)
 // Firefox 22 (unprefixed)
 // Internet Explorer 11 (unprefixed)
 

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -20,11 +20,11 @@ $flex-wrap-required : false !default;
 // The modern `flex-direction` property corresponds to two properties in the @box spec.  This 
 // variable allows you to suppress it from being emitted when the `legacy-flex-direction` mixin
 // is invoked:
-//     false  : always emit
-//     true   : always suppress
-//     normal : suppress the `normal` direction
-//     reverse: suppress the `reverse` direction
-$suppress-box-direction: false !default;
+//     true   : always emit
+//     false  : always suppress
+//     normal : only emit if the direction is `normal`
+//     reverse: only emit if the direction is `reverse`
+$flex-legacy-direction: true !default;
 
 // @flex
 // September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
@@ -124,7 +124,7 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 // ====================================================================================================
 
 // $value: <'flex-direction'> || <'flex-wrap'>
-@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $suppress: $suppress-box-direction) {
+@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $direction: $flex-legacy-direction) {
 	@if $legacy and not $wrap {
 		@include legacy-flex-flow($value);
 	}
@@ -132,9 +132,9 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 	@include experimental(flex-flow, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-flow($value: row nowrap, $suppress: $suppress-box-direction) {
+@mixin legacy-flex-flow($value: row nowrap, $direction: $flex-legacy-direction) {
 	@if length($value) > 1 { // @box version doesn't have a shorthand
-		@include legacy-flex-direction(nth($value, 1), $suppress);
+		@include legacy-flex-direction(nth($value, 1), $direction);
 		@include legacy-flex-wrap(nth($value, 2));
 	} @else {
 		$value: unquote($value);
@@ -149,20 +149,20 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 // ----------------------------------------------------------------------
 
 // $value: row | row-reverse | column | column-reverse
-@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $suppress: $suppress-box-direction) {
+@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $direction: $flex-legacy-direction) {
 	@if $legacy and not $wrap {
-		@include legacy-flex-direction($value, $suppress);
+		@include legacy-flex-direction($value, $direction);
 	}
 	
 	@include experimental(flex-direction, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-direction($value: row, $suppress: $suppress-box-direction) {
+@mixin legacy-flex-direction($value: row, $direction: $flex-legacy-direction) {
 	$value: unquote($value);
-	$direction: if($value == row-reverse or $value == column-reverse, reverse, normal);
+	$translated-direction: if($value == row-reverse or $value == column-reverse, reverse, normal);
 	@include experimental(box-orient, if($value == row or $value == row-reverse, horizontal, vertical), $box-support...);
-	@if not $suppress or $suppress != $direction {
-		@include experimental(box-direction, $direction, $box-support...);
+	@if $direction == true or $translated-direction == $direction {
+		@include experimental(box-direction, $translated-direction, $box-support...);
 	}
 }
 

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -20,6 +20,7 @@
 // Opera 15 (webkit prefix)
 // Firefox 22 (unprefixed)
 // Internet Explorer 11 (unprefixed)
+// Safari 6.1 (prefixed)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -7,8 +7,22 @@
 // `box-ordinal-group` property begins indexing at 1, while the modern `order` property begins
 // indexing at 0.
 
-// ---------------------------------------------------------------------- | @flex
+// if `true`, the @box properties will be emitted as part of the normal mixin call
+// (if this is false, you're still free to explicitly call the legacy mixins yourself)
+$flex-legacy-enabled: false !default;
 
+// if `true`, `$flex-legacy-enabled` is treated as false and an `@supports` block is added to 
+// the display property to hide the standard value from versions of Firefox that support the
+// unprefixed properties, but do not support wrapping
+// (this includes suppressing the automatic emittion of @box properties)
+$flex-wrap-required : false !default;
+
+// The modern `flex-direction` property corresponds to two properties in the @box spec.  If this
+// variable is set to false, then `box-direction: normal` will not be emitted.  If either of the 
+// reverse values are used, `box-direction: reverse` will always be emitted.
+$box-direction-normal: true !default;
+
+// @flex
 // September 2012 Candidate Recommendation (http://www.w3.org/TR/2012/CR-css3-flexbox-20120918/)
 // NOTE: FF did not support wrapping until version ??.  Because the `display: flex` property
 // is wrapped in a `@supports (flex-wrap: wrap)` block (when $flex-wrap-required or the $wrap
@@ -17,33 +31,21 @@
 // Chrome 21 (prefixed)
 // Opera 12.1 (unprefixed)
 // Firefox 20 (unprefixed)
-$flex-support: not -moz, -webkit, not -ms, not -o, not -khtml !default;
+$flex-support: not -moz, -webkit, not -o, not -ms, not -khtml !default;
 
-// if `true`, `$flex-legacy-enabled` is treated as false and an `@supports` block is added to 
-// the display property to hide the standard value from versions of Firefox that support the
-// unprefixed properties, but do not support wrapping
-// (this includes suppressing the automatic emittion of @box properties)
-$flex-wrap-required : false !default;
-
-// ---------------------------------------------------------------------- | @flexbox
-
+// @flexbox
 // March 2012 Working Draft (http://www.w3.org/TR/2012/WD-css3-flexbox-20120322/)
 // Chrome 17 (prefixed)
 // Internet Explorer 10 (prefixed)
-$flexbox-support: not -moz, -webkit, -ms, not -o, not -khtml, not standard !default;
+$flexbox-support: not -moz, -webkit, not -o, -ms, not -khtml, not standard !default;
 
-// ---------------------------------------------------------------------- | @box
-
+// @box
 // July 2009 Working Draft (http://www.w3.org/TR/2009/WD-css3-flexbox-20090723/)
 // NOTE: no browser that implements this spec is known to support `box-lines: multiple`
 // Chrome 4? (prefixed)
 // Safari 3.1 (prefixed)
 // Firefox <20 (prefixed)
-$box-support: -moz, -webkit, not -ms, not -o, not -khtml, not standard !default;
-
-// If `true`, the @box properties will be emitted as part of the normal mixin call
-// (if this is false, you're still free to explicitly call the legacy mixins yourself)
-$flex-legacy-enabled: false !default;
+$box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 
 // ====================================================================================================
 //                                                                       | Common
@@ -70,7 +72,7 @@ $flex-legacy-enabled: false !default;
 	@return $value;
 }
 
-@function flex-support-either() {
+@function flex-support-common() {
 	$common: ();
 	@for $i from 1 through length($flex-support) {
 		$common: append($common, nth($flex-support, $i) or nth($flexbox-support, $i), comma);
@@ -118,17 +120,17 @@ $flex-legacy-enabled: false !default;
 // ====================================================================================================
 
 // $value: <'flex-direction'> || <'flex-wrap'>
-@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+@mixin flex-flow($value: row nowrap, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $normal: $box-direction-normal) {
 	@if $legacy and not $wrap {
 		@include legacy-flex-flow($value);
 	}
 	
-	@include experimental(flex-flow, $value, flex-support-either()...);
+	@include experimental(flex-flow, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-flow($value: row nowrap) {
+@mixin legacy-flex-flow($value: row nowrap, $normal: $box-direction-normal) {
 	@if length($value) > 1 { // @box version doesn't have a shorthand
-		@include legacy-flex-direction(nth($value, 1));
+		@include legacy-flex-direction(nth($value, 1), $normal);
 		@include legacy-flex-wrap(nth($value, 2));
 	} @else {
 		$value: unquote($value);
@@ -143,18 +145,20 @@ $flex-legacy-enabled: false !default;
 // ----------------------------------------------------------------------
 
 // $value: row | row-reverse | column | column-reverse
-@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+@mixin flex-direction($value: row, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled, $normal: $box-direction-normal) {
 	@if $legacy and not $wrap {
-		@include legacy-flex-direction($value);
+		@include legacy-flex-direction($value, $normal);
 	}
 	
-	@include experimental(flex-direction, $value, flex-support-either()...);
+	@include experimental(flex-direction, $value, flex-support-common()...);
 }
 
-@mixin legacy-flex-direction($value: row) {
+@mixin legacy-flex-direction($value: row, $normal: $box-direction-normal) {
 	$value: unquote($value);
 	@include experimental(box-orient, if($value == row or $value == row-reverse, horizontal, vertical), $box-support...);
-	@include experimental(box-direction, if($value == row-reverse or $value == column-reverse, reverse, normal), $box-support...);
+	@if $value == row-reverse or $value == column-reverse or $normal {
+		@include experimental(box-direction, if($value == row-reverse or $value == column-reverse, reverse, normal), $box-support...);
+	}
 }
 
 // ----------------------------------------------------------------------
@@ -165,7 +169,7 @@ $flex-legacy-enabled: false !default;
 		@include legacy-flex-wrap($value);
 	}
 	
-	@include experimental(flex-wrap, $value, flex-support-either()...);
+	@include experimental(flex-wrap, $value, flex-support-common()...);
 }
 
 @mixin legacy-flex-wrap($value: nowrap) {
@@ -229,7 +233,7 @@ $flex-legacy-enabled: false !default;
 		@include legacy-flex-grow(nth($value, 1));
 	}
 	
-	@include experimental(flex, $value, flex-support-either()...);
+	@include experimental(flex, $value, flex-support-common()...);
 }
 
 // ----------------------------------------------------------------------

--- a/test/fixtures/stylesheets/compass/css/flexbox.css
+++ b/test/fixtures/stylesheets/compass/css/flexbox.css
@@ -46,11 +46,11 @@
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
-  -webkit-box-align: start;
-  -moz-box-align: start;
   -ms-flex-line-pack: start;
   -webkit-align-content: flex-start;
   align-content: flex-start;
+  -webkit-box-align: baseline;
+  -moz-box-align: baseline;
   -ms-flex-align: baseline;
   -webkit-align-items: baseline;
   align-items: baseline; }

--- a/test/fixtures/stylesheets/compass/css/flexbox.css
+++ b/test/fixtures/stylesheets/compass/css/flexbox.css
@@ -1,20 +1,16 @@
 .flex {
-  display: -webkit-flexbox;
   display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
   -webkit-flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   flex-flow: column nowrap;
-  -webkit-flex-pack: justify;
   -ms-flex-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-flex-line-pack: center;
   -ms-flex-line-pack: center;
   -webkit-align-content: center;
   align-content: center;
-  -webkit-flex-align: end;
   -ms-flex-align: end;
   -webkit-align-items: flex-end;
   align-items: flex-end; }
@@ -23,11 +19,9 @@
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
-  -webkit-flex-item-align: start;
   -ms-flex-item-align: start;
   -webkit-align-self: flex-start;
   align-self: flex-start;
-  -webkit-flex-order: 2;
   -ms-flex-order: 2;
   -webkit-order: 2;
   order: 2; }
@@ -35,7 +29,6 @@
 .flex-legacy {
   display: -webkit-box;
   display: -moz-box;
-  display: -webkit-flexbox;
   display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
@@ -50,17 +43,14 @@
   flex-flow: row nowrap;
   -webkit-box-pack: end;
   -moz-box-pack: end;
-  -webkit-flex-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
   -webkit-box-align: start;
   -moz-box-align: start;
-  -webkit-flex-line-pack: start;
   -ms-flex-line-pack: start;
   -webkit-align-content: flex-start;
   align-content: flex-start;
-  -webkit-flex-align: baseline;
   -ms-flex-align: baseline;
   -webkit-align-items: baseline;
   align-items: baseline; }
@@ -71,33 +61,27 @@
   -webkit-flex: 2 1 20em;
   -ms-flex: 2 1 20em;
   flex: 2 1 20em;
-  -webkit-flex-item-align: stretch;
   -ms-flex-item-align: stretch;
   -webkit-align-self: stretch;
   align-self: stretch;
   -webkit-box-ordinal-group: 4;
   -moz-box-ordinal-group: 4;
-  -webkit-flex-order: 3;
   -ms-flex-order: 3;
   -webkit-order: 3;
   order: 3; }
 
 .flex-legacy {
-  display: -webkit-flexbox;
   display: -ms-flexbox;
   display: -webkit-flex;
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
-  -webkit-flex-pack: distribute;
   -ms-flex-pack: distribute;
   -webkit-justify-content: space-around;
   justify-content: space-around;
-  -webkit-flex-line-pack: stretch;
   -ms-flex-line-pack: stretch;
   -webkit-align-content: stretch;
   align-content: stretch;
-  -webkit-flex-align: start;
   -ms-flex-align: start;
   -webkit-align-items: flex-start;
   align-items: flex-start; }
@@ -111,11 +95,9 @@
   -webkit-flex: 1 2 50%;
   -ms-flex: 1 2 50%;
   flex: 1 2 50%;
-  -webkit-flex-item-align: start;
   -ms-flex-item-align: start;
   -webkit-align-self: flex-start;
   align-self: flex-start;
-  -webkit-flex-order: 1;
   -ms-flex-order: 1;
   -webkit-order: 1;
   order: 1; }


### PR DESCRIPTION
Added a variable here to suppress `box-direction: normal` in instances where it is unnecessary.  Not sure if this should default to true or false, so I've set it to true so that the test doesn't have to be updated.

``` scss
$flex-legacy-enabled: true;
.foo {
    @include flex-direction(row);
}
```

Output:

``` css
.foo {
  -webkit-box-orient: horizontal;
  -moz-box-orient: horizontal;
  -webkit-box-direction: normal;
  -moz-box-direction: normal;
  -webkit-flex-direction: row;
  -ms-flex-direction: row;
  flex-direction: row;
}
```

Since `normal` is the default value for `flex-direction`, there's no reason to to emit it unless we're actually overriding a reverse value set elsewhere.

``` scss
$flex-legacy-enabled: true;
.foo {
    @include flex-direction(row, $normal: false);
}
```

Output:

``` css
.foo {
  -webkit-box-orient: horizontal;
  -moz-box-orient: horizontal;
  -webkit-flex-direction: row;
  -ms-flex-direction: row;
  flex-direction: row;
}
```

Unless someone can find a browser that supports the draft from early 2012 under the -webkit` prefix, I'm recommending setting it to false.  The sources I've been able to dig up indicate that all the mobile devices are either 2009 (the Android emulator confirms this is true for the most recent version, can't confirm for iOS) or standard (Blackberry 10).  Chrome does not support it in v26 (would have to do some digging to find out exactly when it was dropped).

Quick support demo:  http://codepen.io/cimmanon/pen/gFvmx

There seem to be a few other minor changes that slipped in that should have been a separate commit (function was renamed and global variables were reorganized).  Sorry about that.
