### PR TITLE
Make sure Date.today is defined in the gemspec.

### DIFF
--- a/compass.gemspec
+++ b/compass.gemspec
@@ -1,3 +1,5 @@
+require 'date'  # Date.today
+
 path = "#{File.dirname(__FILE__)}/lib"
 require File.join(path, 'compass/version')
 


### PR DESCRIPTION
This was necessary to make compass work when loaded using bundler's :path option.

I'm on MRI 1.9.3.
