### PR TITLE
#1289 Update _sticky-footer.scss

### DIFF
--- a/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
+++ b/frameworks/compass/stylesheets/compass/layout/_sticky-footer.scss
@@ -8,7 +8,8 @@
 
 @mixin sticky-footer($footer-height, $root-selector: unquote("#root"), $root-footer-selector: unquote("#root_footer"), $footer-selector: unquote("#footer")) {
   html, body {
-    height: 100%; }
+    min-height: 100%;
+    height: auto;  }
   #{$root-selector} {
     clear: both;
     min-height: 100%;


### PR DESCRIPTION
Make sure body extends to bottom of document, not just 100% of page, so background images continue below the footer.
