### PR TITLE
Removed -moz-box-shadow

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_box-shadow.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_box-shadow.scss
@@ -45,7 +45,7 @@ $default-box-shadow-inset : false !default;
   }
   $shadow : compact($shadow-1, $shadow-2, $shadow-3, $shadow-4, $shadow-5, $shadow-6, $shadow-7, $shadow-8, $shadow-9, $shadow-10);
   @include experimental(box-shadow, $shadow,
-    -moz, -webkit, not -o, not -ms, not -khtml, official
+    not -moz, -webkit, not -o, not -ms, not -khtml, official
   );
 }
 


### PR DESCRIPTION
Gecko 13 (Firefox 13) removed support for -moz-box-shadow. Since then, only the unprefixed version is supported. https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow
