### PR TITLE
Smart layout now considers spacing, should fix #718

### DIFF
--- a/lib/compass/sass_extensions/sprites/engines/chunky_png_engine.rb
+++ b/lib/compass/sass_extensions/sprites/engines/chunky_png_engine.rb
@@ -9,10 +9,10 @@ module Compass
     module Sprites
       class ChunkyPngEngine < Compass::SassExtensions::Sprites::Engine
 
-        def construct_sprite
+        def construct_sprite                    
           @canvas = ChunkyPNG::Image.new(width, height, ChunkyPNG::Color::TRANSPARENT)
           images.each do |image|
-            input_png  = ChunkyPNG::Image.from_file(image.file)
+            input_png  = ChunkyPNG::Image.from_file(image.file)                 
             canvas.replace! input_png, image.left, image.top
           end
         end    

--- a/lib/compass/sass_extensions/sprites/image_row.rb
+++ b/lib/compass/sass_extensions/sprites/image_row.rb
@@ -9,13 +9,13 @@ module Compass
         attr_reader :images, :max_width
         def_delegators :@images, :last, :delete, :empty?, :length
         
-        def initialize(max_width)
+        def initialize(max_width)          
           @images = []
           @max_width = max_width
         end
         
         def add(image)
-          return false if !will_fit?(image)
+          return false if !will_fit?(image)          
           @images << image
           true
         end
@@ -23,15 +23,15 @@ module Compass
         alias :<< :add
         
         def height
-          images.map(&:height).max
+          return (images.map(&:height).max + images.map(&:spacing).max)
         end
         
-        def width
+        def width          
           images.map(&:width).max
         end
 
         def total_width
-          images.inject(0) {|sum, img| sum + img.width }
+          images.inject(0) {|sum, img| sum + img.width + img.spacing}
         end
         
         def efficiency
@@ -39,7 +39,7 @@ module Compass
         end
 
         def will_fit?(image)
-          (total_width + image.width) <= max_width
+          (total_width + image.width + image.spacing) <= max_width
         end
       end
     end

--- a/lib/compass/sass_extensions/sprites/layout_methods.rb
+++ b/lib/compass/sass_extensions/sprites/layout_methods.rb
@@ -29,10 +29,10 @@ module Compass
         
         # Calculates the overal image dimensions
         # collects image sizes and input parameters for each sprite
-        def compute_image_positions!
+        def compute_image_positions!                    
           case layout
-          when SMART
-            calculate_smart_positions
+          when SMART                        
+            calculate_smart_positions            
           when DIAGONAL
             calculate_diagonal_dimensions
             calculate_diagonal_positions
@@ -84,13 +84,15 @@ module Compass
         def calculate_smart_positions
           fitter = ::Compass::SassExtensions::Sprites::RowFitter.new(@images)
           current_y = 0
+          spacing = 0;          
           fitter.fit!.each do |row|
-            current_x = 0
+            current_x = 0            
             row.images.each_with_index do |image, index|
               image.left = current_x
-              image.top = current_y
-              current_x += image.width
-            end
+              image.top = current_y              
+              current_x += image.width + image.spacing
+              spacing = image.spacing              
+            end                        
             current_y += row.height
           end
           @width = fitter.width

--- a/lib/compass/sass_extensions/sprites/row_fitter.rb
+++ b/lib/compass/sass_extensions/sprites/row_fitter.rb
@@ -9,7 +9,7 @@ module Compass
         attr_reader :images, :rows
         def_delegators :rows, :[]
 
-        def initialize(images)
+        def initialize(images)          
           @images = images.sort do |a,b|
             if a.height == b.height
               b.width <=> a.width
@@ -17,7 +17,7 @@ module Compass
               a.height <=> b.height
             end
           end
-          @rows = []
+          @rows = []        
         end
 
         def fit!(style = :scan)
@@ -26,11 +26,11 @@ module Compass
         end
 
         def width
-          @width ||= @images.collect(&:width).max
+          @width ||= @images.collect(&:width).max + @images.collect(&:spacing).max
         end
         
         def height
-          @height ||= @rows.inject(0) {|sum, row| sum += row.height}
+          @height ||= @rows.inject(0) {|sum, row| sum += row.height} + @images[0].spacing
         end
 
         def efficiency
@@ -38,29 +38,29 @@ module Compass
         end
 
         private
-        def new_row(image = nil)
+        def new_row(image = nil)          
           row = Compass::SassExtensions::Sprites::ImageRow.new(width)
           row.add(image) if image
           row
         end
 
         def fast_fit
-          row = new_row
-          @images.each do |image|
-            if !row.add(image)
-              @rows << row
-              row = new_row(image)
+          row = new_row          
+          @images.each do |image|            
+            if !row.add(image)              
+              @rows << row              
+              row = new_row(image)            
             end
           end
 
-          @rows << row
+          @rows << row          
         end
 
         def scan_fit
           fast_fit
 
           moved_images = []
-
+          
           begin
             removed = false
 


### PR DESCRIPTION
I basically added the spacing to every width and height computation, both for every image row in the smart layout fitter and in the fitter itself.

Since the output of this commit is a .png file with the sprite, I don't know how to build tests for this; however, since the changes are quite small and straightforward, and I have run some testing on different sets of images myself, I think it shouldn't break any of the existing behaviors.

Attached is a pair of sprites generated with smart layout, with 30px spacing and without the spacing rule in the .scss:

No spacing:
![registrazione-s05deac8370](https://f.cloud.github.com/assets/1030142/586934/fc3948ca-c959-11e2-87a0-4fe0d9b85b4b.png)

30px spacing:
![registrazione-s9bc14f8201](https://f.cloud.github.com/assets/1030142/586949/370c06fe-c95a-11e2-937e-e59dd7804809.png)
