### PR TITLE
font-face and link-colors updates

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_font-face.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_font-face.scss
@@ -8,6 +8,15 @@
 // * $eot is required by IE, and is a relative location of the eot file.
 // * $weight shows if the font is bold, defaults to normal
 // * $style defaults to normal, might be also italic
+// * $unicode-range is if you want to load only a specific glyph of the font
+// * $local is if you want to load the font found on the visitor's machine
+//
+// * Example:
+//    @include font-face( "BaybayinModernSinta", font-files( "baybayin_sin-webfont.woff", "baybayin_sin-webfont.ttf", "baybayin_sin-webfont.svg#webfontof6oMF40" ), "baybayin_sin-webfont.eot", normal, normal, (U+1700-1714, U+1735-1736), ☺ );
+//
+// * Note: $unicode-range and $local were added after $style to keep the format backwards-compatible.
+//    Otherwise, existing users will have to redo all their font-face mixin calls.
+//
 // * For android 2.2 Compatiblity, please ensure that your web page has
 //   a meta viewport tag.
 // * To support iOS < 4.2, an SVG file must be provided
@@ -15,7 +24,6 @@
 // If you need to generate other formats check out the Font Squirrel
 // [font generator](http://www.fontsquirrel.com/fontface/generator)
 //
-
 // In order to refer to a specific style of the font in your stylesheets as
 // e.g. "font-style: italic;",  you may add a couple of @font-face includes
 // containing the respective font files for each style and specying
@@ -28,7 +36,9 @@
   $font-files,
   $eot: false,
   $weight: false,
-  $style: false
+  $style: false,
+  $unicode-range: false,
+  $local: false
 ) {
   $iefont: unquote("#{$eot}?#iefix");
   @font-face {
@@ -37,7 +47,14 @@
       src: font-url($eot);
       $font-files: font-url($iefont) unquote("format('embedded-opentype')"), $font-files;
     }
-    src: $font-files;
+    @if $local {
+      src: local(quote($local)), $font-files;
+    } @else {
+      src: $font-files;
+    }
+    @if $unicode-range {
+      unicode-range: $unicode-range;
+    }
     @if $weight {
       font-weight: $weight;
     }

--- a/frameworks/compass/stylesheets/compass/typography/links/_link-colors.scss
+++ b/frameworks/compass/stylesheets/compass/typography/links/_link-colors.scss
@@ -7,6 +7,9 @@
 // 4. visited
 // 5. focus
 //
+// However, the CSS output is: Normal-Visited-Hover-Focus-Active
+// mixin argument order was not changed to keep it backwards-compatible
+//
 // Those states not specified will inherit.
 // Mixin to an anchor link like so:
 //     a
@@ -17,12 +20,12 @@
   @if $visited {
     &:visited {
       color: $visited; } }
-  @if $focus {
-    &:focus {
-      color: $focus; } }
   @if $hover {
     &:hover {
       color: $hover; } }
+  @if $focus {
+    &:focus {
+      color: $focus; } }
   @if $active {
     &:active {
       color: $active; } } }

--- a/test/fixtures/stylesheets/compass/css/fonts.css
+++ b/test/fixtures/stylesheets/compass/css/fonts.css
@@ -1,4 +1,7 @@
 @font-face {
   font-family: "font1";
   src: url('/tmp/fonts/font1.eot');
-  src: url('/tmp/fonts/font1.eot?#iefix') format('embedded-opentype'), url('/tmp/fonts/font1.woff') format('woff'); }
+  src: local("☺"), url('/tmp/fonts/font1.eot?#iefix') format('embedded-opentype'), url('/tmp/fonts/font1.woff') format('woff'), url('/tmp/fonts/font1.ttf') format('truetype'), url('/tmp/fonts/font1.svg') format('svg');
+  unicode-range: U+1700-1714, U+1735-1736;
+  font-weight: normal;
+  font-style: normal; }

--- a/test/fixtures/stylesheets/compass/sass/fonts.sass
+++ b/test/fixtures/stylesheets/compass/sass/fonts.sass
@@ -1,3 +1,3 @@
 @import compass/css3/font-face
 
-+font-face( "font1", font-files( "font1.woff", "font1.ttf", "font1.svg" ), "font1.eot", normal, normal, (U+1700-1714, U+1735-1736), ☺ )
++font-face("font1", font-files("font1.woff", "font1.ttf", "font1.svg"), "font1.eot", normal, normal, (U+1700-1714, U+1735-1736), ☺)

--- a/test/fixtures/stylesheets/compass/sass/fonts.sass
+++ b/test/fixtures/stylesheets/compass/sass/fonts.sass
@@ -1,3 +1,3 @@
 @import compass/css3/font-face
 
-+font-face("font1", font-files("font1.woff", woff), "font1.eot")
++font-face( "font1", font-files( "font1.woff", "font1.ttf", "font1.svg" ), "font1.eot", normal, normal, (U+1700-1714, U+1735-1736), ☺ )


### PR DESCRIPTION
font-face
1) I added unicode-range support (optional)
2) Added local('') support (optional)
- $unicode-range and $local were added after $style to keep compatibility with existing font-face mixin use
- unicode-range for pulling only specific glyph points
- local for either calling a real local font file if it exists, or for those who wants to use the smiley technique
- the CSS output is:
  `@font-face {
  font-family: "font1";
  src: url('/tmp/fonts/font1.eot');
  src: local("☺"), url('/tmp/fonts/font1.eot?#iefix') format('embedded-opentype'), url('/tmp/fonts/font1.woff') format('woff'), url('/tmp/fonts/font1.ttf') format('truetype'), url('/tmp/fonts/font1.svg') format('svg');
  unicode-range: U+1700-1714, U+1735-1736;
  font-weight: normal;
  font-style: normal; }`
- sass format:
  `+font-face("font1", font-files("font1.woff", "font1.ttf", "font1.svg"), "font1.eot", normal, normal, (U+1700-1714, U+1735-1736), ☺)`

link-colors
1) re-ordered the output CSS to Link-Visited-Hover-Focus-Active (mixin arg order remains the same)
