### PR TITLE
Added support for spacing to smart sprite layouts.

### DIFF
--- a/lib/compass/sass_extensions/sprites/layout/smart.rb
+++ b/lib/compass/sass_extensions/sprites/layout/smart.rb
@@ -13,17 +13,36 @@ module Compass
           def calculate_positions!
             fitter = ::Compass::SassExtensions::Sprites::RowFitter.new(@images)
             current_y = 0
+            width = 0
+            height = 0
+            # We set the last_row_spacing to a very high number initially so
+            # no extra spacing will be added to the y offset on the first row.
+            last_row_spacing = 9999
             fitter.fit!.each do |row|
               current_x = 0
+              row_height = 0
+              row_spacing = 0
               row.images.each_with_index do |image, index|
+                extra_y = [image.spacing - last_row_spacing,0].max
+                if index > 0
+                  last_image = row.images[index-1]
+                  current_x += [image.spacing, last_image.spacing].max
+                end
                 image.left = current_x
-                image.top = current_y
+                image.top = current_y + extra_y
                 current_x += image.width
+                width = [width, current_x].max
+                row_height = [row_height, extra_y+image.height].max
+                row_spacing = [row_spacing, extra_y+image.height+image.spacing].max
               end
-              current_y += row.height
+              current_y += row_height
+              height = [height,current_y].max
+              row_spacing -= row_height
+              current_y += row_spacing
+              last_row_spacing = row_spacing
             end
-            @width = fitter.width
-            @height = fitter.height
+            @width = width
+            @height = height
           end
 
         end


### PR DESCRIPTION
This makes no changes to the RowFitter calculations - it merely adds spacing around the sprites after they've already been divided into rows. As a result, this could potentially generate a suboptimal layout given the right combination of images and spacing settings, but I suspect that would be fairly unlikely in most use cases. If it is deemed to be a major issue, the RowFitter algorithm could always be optimised at a later stage.
