### PR TITLE
Update _flexbox.scss

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -53,7 +53,7 @@ $box-support: -moz, -webkit, not -o, not -ms, not -khtml, not standard !default;
 
 // If `true`, the @box properties will be emitted as part of the normal mixin call
 // (if this is false, you're still free to explicitly call the legacy mixins yourself)
-$flex-legacy-enabled: false !default;
+$flex-legacy-enabled: true !default;
 
 // @doc off
 
@@ -206,24 +206,24 @@ $flex-legacy-enabled: false !default;
 // Distributing extra space along the "cross axis"
 // $value: flex-start | flex-end | center | space-between | space-around | stretch
 @mixin align-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
-	@if $legacy and not $wrap {
-		@include legacy-align-content($value);
-	}
+	// There is no @box version of this property
 
 	@include experimental(flex-line-pack, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(align-content, $value, $flex-support...);
 }
 
-@mixin legacy-align-content($value: flex-start) {
-	@include experimental(box-align, flex-translate-value($value, box), $box-support...);
-}
-
 // Align items along the "cross axis"
 // $value: flex-start | flex-end | center | baseline | stretch
 @mixin align-items($value: stretch) { // the flex container
-	// There is no @box version of this property
+	@if $legacy and not $wrap {
+		@include legacy-align-items($value);
+	}
 	@include experimental(flex-align, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(align-items, $value, $flex-support...);
+}
+
+@mixin legacy-align-items($value: flex-start) {
+	@include experimental(box-align, flex-translate-value($value, box), $box-support...);
 }
 
 // @doc off

--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -205,16 +205,15 @@ $flex-legacy-enabled: true !default;
 
 // Distributing extra space along the "cross axis"
 // $value: flex-start | flex-end | center | space-between | space-around | stretch
-@mixin align-content($value: flex-start, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) {
+@mixin align-content($value: flex-start) {
 	// There is no @box version of this property
-
 	@include experimental(flex-line-pack, flex-translate-value($value, flexbox), $flexbox-support...);
 	@include experimental(align-content, $value, $flex-support...);
 }
 
 // Align items along the "cross axis"
 // $value: flex-start | flex-end | center | baseline | stretch
-@mixin align-items($value: stretch) { // the flex container
+@mixin align-items($value: stretch, $wrap: $flex-wrap-required, $legacy: $flex-legacy-enabled) { // the flex container
 	@if $legacy and not $wrap {
 		@include legacy-align-items($value);
 	}


### PR DESCRIPTION
Notes:
- I don't think browser support is in a place where `$flex-legacy-enabled` should be false by default. It gets situationally set to false if you're doing advanced flexbox stuff anyway, so an "opt-out" policy seems better overall.
- Support for `align-content` & `align-items` was mixed up. `align-content` only takes effect when there's line wrapping, so legacy support is out. `align-items` (`box-align` in the legacy syntax) is the property responsible for cross-axis alignment. (See: http://timhettler.github.io/compass-flexbox/tests.html#align-items)
