### PR TITLE
Allow custom environments

### DIFF
--- a/doc-src/content/help/tutorials/configuration-reference.markdown
+++ b/doc-src/content/help/tutorials/configuration-reference.markdown
@@ -102,7 +102,9 @@ later on.
     <td style="vertical-align:top;"><code>environment</code> </td>
     <td style="vertical-align:top;">Symbol </td>
     <td style="vertical-align:top;">The environment mode.
-      Defaults to <code>:production</code>, can also be <code>:development</code>
+      Defaults to <code>:development</code>, traditionally one of <code>:development</code> or <code>:production</code>
+      but any environment string can be provided. Custom environments will use the defaults of the 
+      <code>:development</code> environment unless overwridden.
     </td>
   </tr>
   <tr>

--- a/doc-src/content/help/tutorials/configuration-reference.markdown
+++ b/doc-src/content/help/tutorials/configuration-reference.markdown
@@ -103,8 +103,8 @@ later on.
     <td style="vertical-align:top;">Symbol </td>
     <td style="vertical-align:top;">The environment mode.
       Defaults to <code>:development</code>, traditionally one of <code>:development</code> or <code>:production</code>
-      but any environment string can be provided. Custom environments will use the defaults of the 
-      <code>:development</code> environment unless overwridden.
+      but any environment string can be provided. Custom environments will use the defaults of the
+      <code>:development</code> environment unless overridden.
     </td>
   </tr>
   <tr>

--- a/lib/compass/configuration/defaults.rb
+++ b/lib/compass/configuration/defaults.rb
@@ -27,7 +27,7 @@ module Compass
       end
 
       def default_output_style
-        if top_level.environment == :development
+        if top_level.environment != :production
           :expanded
         else
           :compressed
@@ -35,7 +35,7 @@ module Compass
       end
 
       def default_line_comments
-        top_level.environment == :development
+        top_level.environment != :production
       end
 
       def default_color_output

--- a/lib/compass/exec/project_options_parser.rb
+++ b/lib/compass/exec/project_options_parser.rb
@@ -44,9 +44,9 @@ module Compass::Exec::ProjectOptionsParser
       set_dir_or_path(:fonts, fonts_dir)
     end
 
-    opts.on('-e ENV', '--environment ENV', [:development, :production], 'Use sensible defaults for your current environment.',
-            '  One of: development (default), production') do |env|
-      self.options[:environment] = env
+    opts.on('-e ENV', '--environment ENV', 'Use sensible defaults for your current environment.',
+            '  defaults to development') do |env|
+      self.options[:environment] = env || :development
     end
 
     opts.on('-s STYLE', '--output-style STYLE', [:nested, :expanded, :compact, :compressed], 'Select a CSS output mode.',

--- a/test/integrations/compass_test.rb
+++ b/test/integrations/compass_test.rb
@@ -95,6 +95,17 @@ class CompassTest < Test::Unit::TestCase
     end
   end
 
+  def test_env_in_custom_env
+    within_project('envtest', lambda {|c| c.environment = :staging }) do |proj|
+      each_css_file(proj.css_path) do |css_file|
+        assert_no_errors css_file, 'envtest'
+      end
+      each_sass_file do |sass_file|
+        assert_renders_correctly sass_file, :ignore_charset => true, :environment => "staging"
+      end
+    end
+  end
+
   def test_busted_image_urls
     within_project('busted_image_urls') do |proj|
       each_css_file(proj.css_path) do |css_file|


### PR DESCRIPTION
Some usecases require environments like `staging` or `qa`

The restriction to just `development` or `production` for environment makes it difficult to do certain things. 
