### PR TITLE
Improved cache buster handling for font URLs

### DIFF
--- a/lib/compass/sass_extensions/functions/urls.rb
+++ b/lib/compass/sass_extensions/functions/urls.rb
@@ -47,7 +47,7 @@ module Compass::SassExtensions::Functions::Urls
         base.declare :font_url,       [:path, :only_path, :cache_buster]
       end
     end
-    def font_url(path, only_path = Sass::Script::Bool.new(false), cache_buster = Sass::Script::Bool.new(false))
+    def font_url(path, only_path = Sass::Script::Bool.new(false), cache_buster = Sass::Script::Bool.new(true))
       path = path.value # get to the string value of the literal.
 
       # Short curcuit if they have provided an absolute url.


### PR DESCRIPTION
This is an improvement/addition to 727ac80a677af21856de55f575b54387b7b53503.

Font URLs do often contain query strings and/or hashes (e.g. "example.eot?#iefix" or "example.svg#my-font"). This patch adds support for cache busters in combination with such font URLs.

Besides that, I changed the default value of font_url's :cache_buster argument to true, just like with image_url. I think that's more consistent.
