### PR TITLE
Fix woff mimetype to be consistent with latest W3 spec.

### DIFF
--- a/lib/compass/sass_extensions/functions/inline_image.rb
+++ b/lib/compass/sass_extensions/functions/inline_image.rb
@@ -44,7 +44,7 @@ private
     when /\.ttf$/i
       'font/truetype'
     when /\.woff$/i
-      'application/x-font-woff'
+      'application/font-woff'
     when /\.off$/i
       'font/openfont'
     when /\.([a-zA-Z]+)$/


### PR DESCRIPTION
The W3 spec now says that mimetype for woff fonts should be: application/font-woff

http://www.w3.org/TR/WOFF/#appendix-b

See:
- http://zduck.com/2013/google-chrome-and-woff-font-mime-type-warnings/
- http://stackoverflow.com/questions/16704967/resource-interpreted-as-font-but-transferred-with-mime-type-application-x-font-w

note: This was changed before in compass about a year and a half ago: https://github.com/chriseppstein/compass/pull/755  

Now it seems to need changed again.
