### PR TITLE
New mixin use-baseline in vertical rhythm module

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -131,12 +131,12 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
 // for rem output.
 // Include the $img argument if you would rather use your own image than the
 // Compass default gradient image.
-@mixin debug-vertical-alignment($img: false) {
+@mixin debug-vertical-alignment($img: false, $font-size: $base-font-size) {
   @if $img {
     background: image-url($img);
   }
   @else {
-    @include baseline-grid-background(rhythm(1, $base-font-size));
+    @include baseline-grid-background(rhythm(1, $font-size));
   }
 }
 
@@ -298,17 +298,14 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
   @include apply-side-rhythm-border(all, $width, $lines, $font-size, $border-style);
 }
 
-// Use an alternative baseline than the established one. Mixins and functions
-// called in this context will use the given $base-font-size and $base-line-height.
-@mixin use-baseline($new-base-size, $new-line-height) {
-  // Save the baseline context
+// Switch baseline context.
+// It takes a list of targeted font size and line height as argument.
+@mixin use-baseline($alt-baseline...) {
   $initial-font-size: $base-font-size;
   $initial-line-height: $base-line-height;
-  // Apply the new context
-  $base-font-size: $new-base-size;
-  $base-line-height: $new-line-height;
+  $base-font-size: nth($alt-baseline, 1);
+  $base-line-height: nth($alt-baseline, 2);
   @content;
-  // Reapply the initial context
   $base-font-size: $initial-font-size;
   $base-line-height: $initial-line-height;
 }

--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -30,14 +30,6 @@ $round-to-nearest-half-line: false !default;
 // of vertical padding above and below the text.
 $min-line-padding: 2px !default;
 
-// The leader is the amount of whitespace in a line.
-// It might be useful in your calculations.
-$base-leader: convert-length($base-line-height - $base-font-size, $rhythm-unit, $base-font-size);
-
-// The half-leader is the amount of whitespace above and below a line.
-// It might be useful in your calculations.
-$base-half-leader: $base-leader / 2;
-
 // @private Whether the rhythm output is in absolute units (px) or not (em, rem)
 $relative-font-sizing: if($rhythm-unit == px, false, true);
 
@@ -48,6 +40,25 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
   @warn "$rhythm-unit must be `px`, `em` or `rem`.";
 }
 
+// Calculate base leader :
+// The leader is the amount of whitespace in a line.
+// It might be useful in your calculations.
+@function base-leader(
+  $base-font-size: $base-font-size,
+  $base-line-height: $base-line-height
+) {
+  @return convert-length($base-line-height - $base-font-size, $rhythm-unit, $base-font-size);
+}
+
+// Calculate base half leader :
+// The half-leader is the amount of whitespace above and below a line.
+// It might be useful in your calculations.
+@function base-half-leader(
+  $base-font-size: $base-font-size,
+  $base-line-height: $base-line-height
+) {
+  @return base-leader() / 2;
+}
 
 // Calculate rhythm units.
 @function rhythm($lines: 1, $font-size: $base-font-size, $offset: 0) {

--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -136,7 +136,7 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
     background: image-url($img);
   }
   @else {
-    @include baseline-grid-background(rhythm());
+    @include baseline-grid-background(rhythm(1, $base-font-size));
   }
 }
 
@@ -296,4 +296,19 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
   $border-style: $default-rhythm-border-style
 ) {
   @include apply-side-rhythm-border(all, $width, $lines, $font-size, $border-style);
+}
+
+// Use an alternative baseline than the established one. Mixins and functions
+// called in this context will use the given $base-font-size and $base-line-height.
+@mixin use-baseline($new-base-size, $new-line-height) {
+  // Save the baseline context
+  $initial-font-size: $base-font-size;
+  $initial-line-height: $base-line-height;
+  // Apply the new context
+  $base-font-size: $new-base-size;
+  $base-line-height: $new-line-height;
+  @content;
+  // Reapply the initial context
+  $base-font-size: $initial-font-size;
+  $base-line-height: $initial-line-height;
 }

--- a/test/fixtures/stylesheets/compass/sass/vertical_rhythm.scss
+++ b/test/fixtures/stylesheets/compass/sass/vertical_rhythm.scss
@@ -23,12 +23,14 @@
 // * trailing-border
 // * rhythm-borders
 // * horizontal-borders (h-borders)
+// * use-baseline
 //
 // deprecated mixins:
 // * reset-baseline
 
 $base-font-size: 14px;
 $base-line-height: 16px;
+$alternative-baseline: 18px 25px;
 @import "compass/typography/vertical_rhythm";
 
 @include establish-baseline;
@@ -59,6 +61,11 @@ $base-line-height: 16px;
 	@include reset-baseline;
 }
 
+#alternative-baseline {
+	@include use-baseline($alternative-baseline...) {
+		// ...
+	}
+}
 
 /* New test using em output */
 $base-font-size: 18px;
@@ -113,6 +120,13 @@ blockquote {
 	@include rhythm-borders($font-size: 16px);
 }
 
+#alternative-baseline {
+	@include use-baseline($alternative-baseline...) {
+		// ...
+	}
+}
+
+
 /* New using rem output with pixel fallbacks */
 $base-font-size: 18px;
 $base-line-height: $base-font-size * 1.4;
@@ -162,6 +176,12 @@ blockquote {
 
 .panel {
 	@include rhythm-borders;
+}
+
+#alternative-baseline {
+	@include use-baseline($alternative-baseline...) {
+		// ...
+	}
 }
 
 /* New using px output */
@@ -215,3 +235,8 @@ blockquote {
 	@include rhythm-borders;
 }
 
+#alternative-baseline {
+	@include use-baseline($alternative-baseline...) {
+		// ...
+	}
+}


### PR DESCRIPTION
Discussed with @ericam here : https://groups.google.com/forum/#!topic/compass-users/NecGNw31Rzc

The mixin takes a variable argument list of base font size, base line height and changes the context for the given block.

@debug-grid-background needed an additional argument, as it relies on the current value of $base-font-size which may be the wrong one. I didn't find any other mixin of function to patch.

I also made $base-leader and $base-half-leader function since they can mistakenly be used in the alternative baseline context without taking it into account. If this change is a problem, we should may be warn the user in the doc ?

Concerning the tests, I just added the new mixin in test/fixtures/stylesheets/compass/sass/vertical-rhythm, is that enough ?
