### PR TITLE
fixed a bug with inline-image in opera and IE

### DIFF
--- a/lib/compass/sass_extensions/functions/inline_image.rb
+++ b/lib/compass/sass_extensions/functions/inline_image.rb
@@ -27,7 +27,7 @@ protected
 
 private
   def compute_mime_type(path, mime_type = nil)
-    return mime_type if mime_type
+    return mime_type.value if mime_type
     case path
     when /\.png$/i
       'image/png'


### PR DESCRIPTION
When you specify the mimetype with quotes like so: inline-image('content-bgr.png', 'image/png'); it is written in the css with double quotes and this breaks it in Opera(found in 12) and IE (found in 8 and 9). This fixes it.
