### PR TITLE
Remove -webkit-flexbox

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_flexbox.scss
@@ -17,7 +17,9 @@
 // finally added
 // Chrome 21 (prefixed)
 // Opera 12.1 (unprefixed)
-// Firefox 20 (unprefixed)
+// Firefox 22 (unprefixed)
+// Internet Explorer 11 (unprefixed)
+// Safari 6.1 (prefixed)
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
@@ -37,7 +39,7 @@ $flex-wrap-required : false !default;
 
 // @private css3-feature-support variables must always include a list of five boolean values
 // representing in order: -moz, -webkit, -o, -ms, -khtml.
-$flexbox-support: not -moz, -webkit, not -o, -ms, not -khtml, not standard !default;
+$flexbox-support: not -moz, not -webkit, not -o, -ms, not -khtml, not standard !default;
 
 // @private Box
 // ------------

--- a/test/fixtures/stylesheets/compass/css/flexbox.css
+++ b/test/fixtures/stylesheets/compass/css/flexbox.css
@@ -1,20 +1,16 @@
 .flex {
-  display: -webkit-flexbox;
   display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
   -webkit-flex-flow: column nowrap;
   -ms-flex-flow: column nowrap;
   flex-flow: column nowrap;
-  -webkit-flex-pack: justify;
   -ms-flex-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
-  -webkit-flex-line-pack: center;
   -ms-flex-line-pack: center;
   -webkit-align-content: center;
   align-content: center;
-  -webkit-flex-align: end;
   -ms-flex-align: end;
   -webkit-align-items: flex-end;
   align-items: flex-end; }
@@ -23,11 +19,9 @@
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
-  -webkit-flex-item-align: start;
   -ms-flex-item-align: start;
   -webkit-align-self: flex-start;
   align-self: flex-start;
-  -webkit-flex-order: 2;
   -ms-flex-order: 2;
   -webkit-order: 2;
   order: 2; }
@@ -35,7 +29,6 @@
 .flex-legacy {
   display: -webkit-box;
   display: -moz-box;
-  display: -webkit-flexbox;
   display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
@@ -50,17 +43,14 @@
   flex-flow: row nowrap;
   -webkit-box-pack: end;
   -moz-box-pack: end;
-  -webkit-flex-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
   -webkit-box-align: start;
   -moz-box-align: start;
-  -webkit-flex-line-pack: start;
   -ms-flex-line-pack: start;
   -webkit-align-content: flex-start;
   align-content: flex-start;
-  -webkit-flex-align: baseline;
   -ms-flex-align: baseline;
   -webkit-align-items: baseline;
   align-items: baseline; }
@@ -71,33 +61,27 @@
   -webkit-flex: 2 1 20em;
   -ms-flex: 2 1 20em;
   flex: 2 1 20em;
-  -webkit-flex-item-align: stretch;
   -ms-flex-item-align: stretch;
   -webkit-align-self: stretch;
   align-self: stretch;
   -webkit-box-ordinal-group: 4;
   -moz-box-ordinal-group: 4;
-  -webkit-flex-order: 3;
   -ms-flex-order: 3;
   -webkit-order: 3;
   order: 3; }
 
 .flex-legacy {
-  display: -webkit-flexbox;
   display: -ms-flexbox;
   display: -webkit-flex;
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;
-  -webkit-flex-pack: distribute;
   -ms-flex-pack: distribute;
   -webkit-justify-content: space-around;
   justify-content: space-around;
-  -webkit-flex-line-pack: stretch;
   -ms-flex-line-pack: stretch;
   -webkit-align-content: stretch;
   align-content: stretch;
-  -webkit-flex-align: start;
   -ms-flex-align: start;
   -webkit-align-items: flex-start;
   align-items: flex-start; }
@@ -111,11 +95,9 @@
   -webkit-flex: 1 2 50%;
   -ms-flex: 1 2 50%;
   flex: 1 2 50%;
-  -webkit-flex-item-align: start;
   -ms-flex-item-align: start;
   -webkit-align-self: flex-start;
   align-self: flex-start;
-  -webkit-flex-order: 1;
   -ms-flex-order: 1;
   -webkit-order: 1;
   order: 1; }


### PR DESCRIPTION
There's no such thing as `-webkit-flexbox`. This pull request disables `-webkit`-prefixing the 2012 Working Draft flex properties.

Also, browser support information is updated - I added info about IE & Safari and corrected Firefox info (the CR Flexbox has been available in Firefox since version 22, not 20).
