### PR TITLE
Add functions to return sprite image dimensions

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -8,11 +8,21 @@ $sprite-selectors: hover, target, active !default;
   width: image-width(sprite-file($map, $sprite));
 }
 
+// Return the width of an image in the sprite map
+@function sprite-width($map, $sprite) {
+    @return image-width(sprite-file($map, $sprite));
+}
+
+// Return the height of an image in the sprite map
+@function sprite-height($map, $sprite) {
+    @return image-height(sprite-file($map, $sprite));
+}
+
 // Set the background position of the given sprite `$map` to display the
 // sprite of the given `$sprite` name. You can move the image relative to its
 // natural position by passing `$offset-x` and `$offset-y`.
 @mixin sprite-background-position($map, $sprite, $offset-x: 0, $offset-y: 0) {
-  background-position: sprite-position($map, $sprite, $offset-x, $offset-y);  
+  background-position: sprite-position($map, $sprite, $offset-x, $offset-y);
 }
 
 
@@ -34,7 +44,7 @@ $disable-magic-sprite-selectors:false !default;
   }
 }
 
-// Include the selectors for the `$sprite` given the `$map` and the 
+// Include the selectors for the `$sprite` given the `$map` and the
 // `$full-sprite-name`
 // @private
 @mixin sprite-selectors($map, $sprite-name, $full-sprite-name, $offset-x: 0, $offset-y: 0) {


### PR DESCRIPTION
Hi guys.

Last week I created these functions, and I'd like to see this in the Compass Core

I case of use

``` scss
$my-sprite-map: sprite-map("my-folder/*.png");

.my-element {
    $height: sprite-height($my-sprite-map, "some-amazing-image");
    position: absolute;
    top: -($height / 2);
    left: 0;

    background: sprite($my-sprite-map, "some-amazing-image");
    width: sprite-width($my-sprite-map, "some-amazing-image") - 10px;
    height: $height - 10px;
}
```

**Note**: I don't have tested this snippets... sorry for some possible stupid error.

I don't know how I can test this in ruby, because I don't know ruby :/ but is just it :)

Att
