### PR TITLE
Changing sprite background image declaration to 'background-image'

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_sprite-img.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_sprite-img.scss
@@ -38,7 +38,7 @@ $sprite-image-default-height: $sprite-default-size !default;
 
 // Sets rules common for all sprites, assumes a rectangular region.
 @mixin sprite-background-rectangle($img, $width: $sprite-image-default-width, $height: $sprite-image-default-height) {
-  background: image-url($img) no-repeat;
+  background-image: image-url($img) no-repeat;
   width: $width;
   height: $height;
   overflow: hidden; 


### PR DESCRIPTION
Using plain-old 'background' was causing inconsistent behavior (i.e. all sprites starting at 0,0) in a very large project I'm working on.
