### PR TITLE
Disable alpha transformation if opacity is 100%

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_opacity.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_opacity.scss
@@ -7,7 +7,11 @@
 
 @mixin opacity($opacity) {
   @if $legacy-support-for-ie6 or $legacy-support-for-ie7 or $legacy-support-for-ie8 {
-    filter: unquote("progid:DXImageTransform.Microsoft.Alpha(Opacity=#{round($opacity * 100)})");
+    @if $opacity == 1 {
+      filter: unquote("progid:DXImageTransform.Microsoft.Alpha(enabled=false)");
+    } @else {
+      filter: unquote("progid:DXImageTransform.Microsoft.Alpha(Opacity=#{round($opacity * 100)})");
+    }
   }
   opacity: $opacity;
 }

--- a/test/fixtures/stylesheets/compass/css/opacity.css
+++ b/test/fixtures/stylesheets/compass/css/opacity.css
@@ -1,3 +1,7 @@
 div {
+  filter: progid:DXImageTransform.Microsoft.Alpha(enabled=false);
+  opacity: 1; }
+
+div {
   filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=20);
   opacity: 0.2; }

--- a/test/fixtures/stylesheets/compass/sass/opacity.scss
+++ b/test/fixtures/stylesheets/compass/sass/opacity.scss
@@ -1,5 +1,9 @@
 @import "compass/css3/opacity";
 
 div {
+  @include opacity(1);
+}
+
+div {
   @include opacity(.2);
 }


### PR DESCRIPTION
IE 8 does not display overflowing content on elements that have both a z-index
and an alpha channel transformation (opacity).

Since disabling the alpha channel transformation is visually equivalent
to setting it to 100%, we may as well just disable it in these cases.
