### PR TITLE
Auto-requiring compass command-line extensions & loading ad-hoc command-line extensions

### DIFF
--- a/lib/compass/commands.rb
+++ b/lib/compass/commands.rb
@@ -10,3 +10,9 @@ require 'compass/commands/registry'
 ).each do |lib|
   require "compass/commands/#{lib}"
 end
+
+Gem.find_files("compass-*").map{|f| File.basename(f, ".rb")}.each do |compass_extension|
+  require compass_extension
+end
+Compass.discover_extensions!
+

--- a/lib/compass/commands.rb
+++ b/lib/compass/commands.rb
@@ -11,8 +11,4 @@ require 'compass/commands/registry'
   require "compass/commands/#{lib}"
 end
 
-Gem.find_files("compass-*").map{|f| File.basename(f, ".rb")}.each do |compass_extension|
-  require compass_extension
-end
 Compass.discover_extensions!
-

--- a/lib/compass/configuration/helpers.rb
+++ b/lib/compass/configuration/helpers.rb
@@ -106,7 +106,15 @@ module Compass
           end
           add_configuration(data)
         else
-          add_configuration(options[:project_type] || configuration.project_type_without_default || (yield if block_given?) || :stand_alone)  
+          add_configuration(options[:project_type] || configuration.project_type_without_default || (yield if block_given?) || :stand_alone)
+        end
+      end
+
+      def discover_gem_extensions!
+        if defined?(Gem)
+          Gem.find_files("compass-*").map{|f| File.basename(f, ".rb")}.each do |compass_extension|
+            require compass_extension
+          end
         end
       end
 
@@ -119,6 +127,7 @@ module Compass
         if File.directory?(configuration.extensions_path)
           Compass::Frameworks.discover(configuration.extensions_path)
         end
+        discover_gem_extensions!
       end
 
       # Returns a full path to the relative path to the project directory

--- a/test/units/command_line_test.rb
+++ b/test/units/command_line_test.rb
@@ -29,6 +29,7 @@ class CommandLineTest < Test::Unit::TestCase
 
   Compass::Frameworks::ALL.each do |framework|
     next if framework.name == "true"
+    next if framework.name == "testing"
     next if framework.name =~ /^_/
     define_method "test_#{framework.name}_installation" do
       within_tmp_directory do


### PR DESCRIPTION
As Chris Eppstein & I discussed at SassConf, this is a much simpler, more efficient, and more powerful solution than my [original proposal](https://github.com/chriseppstein/compass/pull/1261) to fix issue #1053 :-)

Assuming Compass command line extension are created with the naming convention of always being prefixed with "compass-", this will allow you to use that Compass command line extension by just installing the gem. No need for a command_extensions property in the config.rb, nor an extra "require" statement.

This also works with ad-hoc extensions as well (that's what line 17 is for)

If this is approved, then [compass-csslint](https://github.com/Comcast/compass-csslint) & [compass-csscss](https://github.com/Comcast/compass-csscss) will be much easier to use, and it will hopefully open the door up for others to create Compass command line extensions.
