### PR TITLE
debug-vertical-alignment() should respect $round-to-nearest-half-line

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -137,7 +137,7 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
     background: image-url($img);
   }
   @else {
-    @include baseline-grid-background(rhythm());
+    @include baseline-grid-background(if($round-to-nearest-half-line, rhythm(1/2), rhythm(1)));
   }
 }
 


### PR DESCRIPTION
If `$round-to-nearest-half-line` is true, the grid lines generated by `debug-vertical-alignment()` should be positioned at every half of a rhythm unit, rather than a full one.
