### PR TITLE
improved support for inline-font-files(), adds font-formats() method

### DIFF
--- a/lib/compass/sass_extensions/functions/font_files.rb
+++ b/lib/compass/sass_extensions/functions/font_files.rb
@@ -9,33 +9,55 @@ module Compass::SassExtensions::Functions::FontFiles
     :eot => 'embedded-opentype'
   }
 
+  def font_formats(*args)
+    formats = []
+    with_each_font_file(*args) do |path, type|
+      formats << Sass::Script::String.new(type)
+    end
+    return Sass::Script::List.new(formats)
+  end
+
   def font_files(*args)
     files = []
-    args_length = args.length
+    with_each_font_file(*args) do |path, type|
+      files << "#{font_url(path)} format('#{type}')"
+    end
+    Sass::Script::String.new(files.join(", "))
+  end
+
+protected
+  def with_each_font_file(*args)
     skip_next = false
 
-    args.each_with_index do |arg, index|
+    args.each_with_index do |path, index|
+      assert_type path, :String
+      path = unquote(path)
+      # if we were told to skip this iteration, do so...
       if skip_next
         skip_next = false
         next
       end
 
-      type = (args_length > (index + 1)) ? args[index + 1].value.to_sym : :wrong
+      # back-compat support for passing the font type e.g.
+      # font-files('path/to/file.ttf', truetype, 'path/to/file.otf', opentype);
+      type = args[index + 1]
+      type = type.nil? ? :wrong : type.value.to_sym
 
+      # if the type is valid, keep it, and skip the next index (as it was the type)
       if FONT_TYPES.key? type
         skip_next = true
+      # otherwise, we need to look at the file extension to derive the type...
       else
         # let pass url like font.type?thing#stuff
-        type = arg.to_s.split('.').last.gsub(/(\?(.*))?(#(.*))?"/, '').to_sym
+        type = path.to_s.split('.').last.gsub(/(\?(.*))?(#(.*))?\"?/, '').to_sym
       end
 
       if FONT_TYPES.key? type
-        files << "#{font_url(arg)} format('#{FONT_TYPES[type]}')"
+        yield(path, FONT_TYPES[type]) if block_given?
       else
-        raise Sass::SyntaxError, "Could not determine font type for #{arg}"
+        raise Sass::SyntaxError, "Could not determine font type for #{path}"
       end
     end
-
-    Sass::Script::String.new(files.join(", "))
   end
+
 end

--- a/lib/compass/sass_extensions/functions/font_files.rb
+++ b/lib/compass/sass_extensions/functions/font_files.rb
@@ -14,7 +14,7 @@ module Compass::SassExtensions::Functions::FontFiles
     with_each_font_file(*args) do |path, type|
       formats << Sass::Script::String.new(type)
     end
-    return Sass::Script::List.new(formats)
+    return Sass::Script::List.new(formats, :comma)
   end
 
   def font_files(*args)

--- a/lib/compass/sass_extensions/functions/inline_image.rb
+++ b/lib/compass/sass_extensions/functions/inline_image.rb
@@ -7,13 +7,12 @@ module Compass::SassExtensions::Functions::InlineImage
   end
 
   def inline_font_files(*args)
-    raise Sass::SyntaxError, "An even number of arguments must be passed to font_files()" unless args.size % 2 == 0
     files = []
-    while args.size > 0
-      path = args.shift.value
+    with_each_font_file(*args) do |path, type|
+      path = path.value
       real_path = File.join(Compass.configuration.fonts_path, path)
-      url = inline_image_string(data(real_path), compute_mime_type(path))
-      files << "#{url} format('#{args.shift}')"
+      data = inline_image_string(data(real_path), compute_mime_type(path))
+      files << "#{data} format('#{type}')"
     end
     Sass::Script::String.new(files.join(", "))
   end

--- a/test/units/sass_extensions_test.rb
+++ b/test/units/sass_extensions_test.rb
@@ -136,6 +136,9 @@ class SassExtensionsTest < Test::Unit::TestCase
     assert_equal "url(/font/with/no_ext) format('opentype')", evaluate("font_files('/font/with/no_ext', 'otf')")
     assert_equal "url(/font/with/weird.ext) format('truetype')", evaluate("font_files('/font/with/weird.ext', 'ttf')")
 
+    # unquoted path strings used to break because of a regex test
+    assert_equal "url(/font/with/right_ext.woff) format('woff')", evaluate("font_files(unquote('/font/with/right_ext.woff'))")
+
     assert_equal "url(/font/with/right_ext.woff) format('woff'), url(/font/with/right_ext_also.otf) format('opentype')", evaluate("font_files('/font/with/right_ext.woff', '/font/with/right_ext_also.otf')")
     assert_equal "url(/font/with/wrong_ext.woff) format('truetype'), url(/font/with/right_ext.otf) format('opentype')", evaluate("font_files('/font/with/wrong_ext.woff', 'ttf', '/font/with/right_ext.otf')")
 
@@ -182,6 +185,9 @@ class SassExtensionsTest < Test::Unit::TestCase
     Compass.configuration.fonts_path = File.expand_path "../fixtures/fonts", File.dirname(__FILE__)
     base64_string = File.read(File.join(Compass.configuration.fonts_path, "bgrove.base64.txt")).chomp
     assert_equal "url('data:font/truetype;base64,#{base64_string}') format('truetype')", evaluate("inline_font_files('bgrove.ttf', truetype)")
+
+    # without specifying the format
+    assert_equal "url('data:font/truetype;base64,#{base64_string}') format('truetype')", evaluate("inline_font_files('bgrove.ttf')")
   end
 
 

--- a/test/units/sass_extensions_test.rb
+++ b/test/units/sass_extensions_test.rb
@@ -190,6 +190,10 @@ class SassExtensionsTest < Test::Unit::TestCase
     assert_equal "url('data:font/truetype;base64,#{base64_string}') format('truetype')", evaluate("inline_font_files('bgrove.ttf')")
   end
 
+  def test_font_formats
+    assert_equal "woff, truetype, svg, embedded-opentype", evaluate("font-formats('/font/name.woff', woff, '/fonts/name.ttf', '/fonts/name.svg#fontpath', unquote('/fonts/name.eot'))")
+  end
+
 
   def test_image_size_should_respond_to_to_path
     object = mock()


### PR DESCRIPTION
this modifies `inline-font-files` so it can take the same syntax as `font-files`

``` scss
// old syntax (still works)
$files: inline-font-files('path/to/file.ttf', truetype);

// new syntax (without the format specified)
$files: inline-font-files('path/to/file.ttf');
```

this also fixes an issue where `font-files` couldn't take an unquoted string (because of the regex pattern used):

``` scss
$files: font-files( unquote('path/to/file.ttf') );
```

and added a `font-formats` method that will return a list of formats given the above syntaxes:

``` scss
$formats: font-formats('path/to/file.ttf'); // truetype
$formats: font-formats('path/to/file.ext', 'otf'); // opentype
$formats: font-formats('path/to/file.ttf', 'path/to/file.ext', 'otf'); // (truetype, opentype)
```

each of these methods (`font-files`, `inline-font-files`, `font-formats`) each uses shared logic for deriving the format `with_each_font_file`
