### PR TITLE
Added `main` element

### DIFF
--- a/lib/compass/sass_extensions/functions/display.rb
+++ b/lib/compass/sass_extensions/functions/display.rb
@@ -2,7 +2,7 @@ module Compass::SassExtensions::Functions::Display
   DEFAULT_DISPLAY = {
                  "block" => %w{address article aside blockquote center dir div dd details dl dt fieldset
                                figcaption figure form footer frameset h1 h2 h3 h4 h5 h6 hr header hgroup
-                               isindex menu nav noframes noscript ol p pre section summary ul},
+                               isindex main menu nav noframes noscript ol p pre section summary ul},
                 "inline" => %w{a abbr acronym audio b basefont bdo big br canvas cite code command
                                datalist dfn em embed font i img input keygen kbd label mark meter output
                                progress q rp rt ruby s samp select small span strike strong sub
@@ -15,7 +15,7 @@ module Compass::SassExtensions::Functions::Display
     "table-footer-group" => %w{tfoot},
              "table-row" => %w{tr},
             "table-cell" => %w{th td},
-           "html5-block" => %w{article aside details figcaption figure footer header hgroup menu nav
+           "html5-block" => %w{article aside details figcaption figure footer header hgroup main menu nav
                                section summary},
           "html5-inline" => %w{audio canvas command datalist embed keygen mark meter output progress rp
                                rt ruby time video wbr},


### PR DESCRIPTION
The `main` element was [formally added to the HTML5 spec](http://html5doctor.com/the-main-element/) earlier this year and should be reset to `display: block`. `main` element added to both `"block"` and `"html5-block"`
