### PR TITLE
Improve rem() to avoid duplicate values

### DIFF
--- a/frameworks/compass/stylesheets/compass/typography/_units.scss
+++ b/frameworks/compass/stylesheets/compass/typography/_units.scss
@@ -143,7 +143,7 @@ $rem-with-px-fallback: true !default;
 	}
 
 	// Use pixel fallback for browsers that don't understand rem units.
-	@if $use-px-fallback {
+	@if $use-px-fallback and $px-values != $rem-values {
 		#{$property}: $px-values;
 	}
 


### PR DESCRIPTION
Taking the initial example of `@include rem(padding, 0);`, which a developer might want to do if as an easy way to switch between zero and non-zero values, before this patch is applied, the output would be `padding:0;padding:0;`. 

This also works with non-numerical values too - the absurd example of `@include rem(border-style, solid);` would no longer output twice either.
