### PR TITLE
Use placeholders for sprite selectors

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -68,12 +68,15 @@ $default-sprite-separator: "-" !default;
 // Determines if you want to use placeholder instead of class selectors.
 $all-sprites-as-placeholders: false !default;
 
-// Generates a class for each space separated name in `$sprite-names`.
-// The selector will be of the form .<map-name>-<sprite-name>.
+// Generates a selector for each space separated name in `$sprite-names`.
+// The selector will be of the form <base-selector>-<map-name>-<sprite-name>,
+// where <base-selector> defaults to `.`.
 //
 // If a base class is provided, then each class will extend it.
 //
 // If `$dimensions` is `true`, the sprite dimensions will specified.
+// 
+// If `$placeholder-sprite` is `true`, the selector will be a placeholder.
 // 
 // Positions are returned in pixel units. Set `$use_percentages` to true to
 // instead get percentages.

--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -83,14 +83,14 @@ $all-sprites-as-placeholders: false !default;
 @mixin sprites($map, $sprite-names, $base-class: false, $dimensions: false,
                $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0,
                $use-percentages: false,
-               $separator: $default-sprite-separator,
-               $placeholder-sprite: $all-sprites-as-placeholders) {
+               $placeholder-sprite: $all-sprites-as-placeholders,
+               $separator: $default-sprite-separator) {
   $base-selector: if($placeholder-sprite, "%", ".");
   @each $sprite-name in $sprite-names {
     @if sprite_does_not_have_parent($map, $sprite-name) {
-      $full-sprite-name: "#{$base-selector}#{$prefix}#{$separator}#{$sprite-name}";
+      $full-sprite-name: "#{$prefix}#{$separator}#{$sprite-name}";
       @if sprite_has_valid_selector($full-sprite-name) {
-        #{$full-sprite-name} {
+        #{$base-selector}#{$full-sprite-name} {
           @if $base-class { @extend #{$base-class}; }
           @include sprite($map, $sprite-name, $dimensions, $offset-x, $offset-y, 
                           $use-percentages, $separator: $separator);

--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -65,23 +65,29 @@ $default-sprite-separator: "-" !default;
   }
 }
 
+// Determines if you want to use placeholder instead of class selectors.
+$all-sprites-as-placeholders: false !default;
+
 // Generates a class for each space separated name in `$sprite-names`.
-// The class will be of the form .<map-name>-<sprite-name>.
+// The selector will be of the form .<map-name>-<sprite-name>.
 //
 // If a base class is provided, then each class will extend it.
 //
 // If `$dimensions` is `true`, the sprite dimensions will specified.
+// 
 // Positions are returned in pixel units. Set `$use_percentages` to true to
 // instead get percentages.
 @mixin sprites($map, $sprite-names, $base-class: false, $dimensions: false,
                $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0,
                $use-percentages: false,
-               $separator: $default-sprite-separator) {
+               $separator: $default-sprite-separator,
+               $placeholder-sprite: $all-sprites-as-placeholders) {
+  $base-selector: if($placeholder-sprite, "%", ".");
   @each $sprite-name in $sprite-names {
     @if sprite_does_not_have_parent($map, $sprite-name) {
-      $full-sprite-name: "#{$prefix}#{$separator}#{$sprite-name}";
+      $full-sprite-name: "#{$base-selector}#{$prefix}#{$separator}#{$sprite-name}";
       @if sprite_has_valid_selector($full-sprite-name) {
-        .#{$full-sprite-name} {
+        #{$full-sprite-name} {
           @if $base-class { @extend #{$base-class}; }
           @include sprite($map, $sprite-name, $dimensions, $offset-x, $offset-y, 
                           $use-percentages, $separator: $separator);

--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -2,18 +2,19 @@
 
 // General Sprite Defaults
 // You can override them before you import this file.
-$<%= name %>-sprite-dimensions : false !default;
-$<%= name %>-use-percentages   : false !default;
-$<%= name %>-position          : 0% !default;
-$<%= name %>-spacing           : 0 !default;
-$<%= name %>-repeat            : no-repeat !default;
-$<%= name %>-prefix            : '' !default;
-$<%= name %>-clean-up          : true !default;
-$<%= name %>-layout            : vertical !default;
-$<%= name %>-inline            : false !default;
-$<%= name %>-sort-by           : 'none' !default;
-$<%= name %>-class-separator   : $default-sprite-separator !default;
-$<%= name %>-sprite-base-class : ".<%= name %>#{$<%= name %>-class-separator}sprite" !default;
+$<%= name %>-sprite-dimensions  : false !default;
+$<%= name %>-use-percentages    : false !default;
+$<%= name %>-position           : 0% !default;
+$<%= name %>-spacing            : 0 !default;
+$<%= name %>-repeat             : no-repeat !default;
+$<%= name %>-prefix             : '' !default;
+$<%= name %>-clean-up           : true !default;
+$<%= name %>-layout             : vertical !default;
+$<%= name %>-inline             : false !default;
+$<%= name %>-sort-by            : 'none' !default;
+$<%= name %>-class-separator    : $default-sprite-separator !default;
+$<%= name %>-placeholder-sprite : $all-sprites-as-placeholders !default;
+$<%= name %>-sprite-base-class  : "#{if($<%= name %>-placeholder-sprite, "%", ".")}<%= name %>#{$<%= name %>-class-separator}sprite" !default;
 
 <% if skip_overrides %> 
   $<%= name %>-sprites: sprite-map("<%= uri %>", $layout: $<%= name %>-layout, $cleanup: $<%= name %>-clean-up, $spacing: $<%= name %>-spacing, $position : $<%= name %>-position);
@@ -77,11 +78,11 @@ $<%= name %>-sprite-base-class : ".<%= name %>#{$<%= name %>-class-separator}spr
   @include sprite($<%= name %>-sprites, $name, $dimensions, $offset-x, $offset-y, $use-percentages, $separator: $separator);
 }
 
-@mixin <%= name %>-sprites($sprite-names, $dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $separator: $<%= name %>-class-separator) {
-  @include sprites($<%= name %>-sprites, $sprite-names, $<%= name %>-sprite-base-class, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $separator: $separator)
+@mixin <%= name %>-sprites($sprite-names, $dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $separator: $<%= name %>-class-separator, $placeholder-sprite: $<%= name %>-placeholder-sprite) {
+  @include sprites($<%= name %>-sprites, $sprite-names, $<%= name %>-sprite-base-class, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $separator: $separator, $placeholder-sprite)
 }
 
 // Generates a class for each sprited image.
-@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $separator: $<%= name %>-class-separator) {
-  @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $separator: $separator);
+@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $separator: $<%= name %>-class-separator, $placeholder-sprite: $<%= name %>-placeholder-sprite) {
+  @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $separator: $separator, $placeholder-sprite);
 }

--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -78,11 +78,11 @@ $<%= name %>-sprite-base-class  : "#{if($<%= name %>-placeholder-sprite, "%", ".
   @include sprite($<%= name %>-sprites, $name, $dimensions, $offset-x, $offset-y, $use-percentages, $separator: $separator);
 }
 
-@mixin <%= name %>-sprites($sprite-names, $dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $separator: $<%= name %>-class-separator, $placeholder-sprite: $<%= name %>-placeholder-sprite) {
-  @include sprites($<%= name %>-sprites, $sprite-names, $<%= name %>-sprite-base-class, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $separator: $separator, $placeholder-sprite)
+@mixin <%= name %>-sprites($sprite-names, $dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $placeholder-sprite: $<%= name %>-placeholder-sprite, $separator: $<%= name %>-class-separator) {
+  @include sprites($<%= name %>-sprites, $sprite-names, $<%= name %>-sprite-base-class, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $placeholder-sprite, $separator: $separator)
 }
 
 // Generates a class for each sprited image.
-@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $separator: $<%= name %>-class-separator, $placeholder-sprite: $<%= name %>-placeholder-sprite) {
-  @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $separator: $separator, $placeholder-sprite);
+@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0, $use-percentages: $<%= name %>-use-percentages, $placeholder-sprite: $<%= name %>-placeholder-sprite, $separator: $<%= name %>-class-separator) {
+  @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y, $use-percentages, $placeholder-sprite, $separator: $separator);
 }


### PR DESCRIPTION
This pull request is an answer to the issue #1005.

It's important to note that this pull request should not modify any current default behavior for sprites, meaning every code being used today will continue to work perfectly fine.

What this does is give the developer the option to create the sprite selectors as placeholders, so that they won't be emitted to the CSS unless the developer makes use of the sprites by extending these selectors.

There are two ways to making use of this functionality:
1. **Set the newly introduced variable `$all-sprites-as-placeholders` to 'true'**: this will cause all sprite insertions that follow this definition to be output as placeholder;
2. **Set the dynamic sprite specific variable `$<sprite-name>-placeholder-sprite` to 'true'**: this will cause only the specific sprite to be output as placeholder.

Note that the second method overwrites the first, so that you can use them in combination say, for example, to output all sprite as placeholders but one specific, by doing the first option and doing the reverse of the second option.
