### PR TITLE
Updated Sinatra integration

### DIFF
--- a/doc-src/content/help/tutorials/integration.markdown
+++ b/doc-src/content/help/tutorials/integration.markdown
@@ -30,7 +30,7 @@ Also checkout this [gist](https://gist.github.com/1184843)
     configure do
       set :haml, {:format => :html5}
       set :scss, {:style => :compact, :debug_info => false}
-      Compass.add_project_configuration(File.join(Sinatra::Application.root, 'config', 'compass.rb'))
+      Compass.add_project_configuration(File.join(settings.root, 'config', 'compass.rb'))
     end
 
     get '/stylesheets/:name.css' do


### PR DESCRIPTION
In fresh version of Sinatra, `Sinatra::Application.root` returns nil.
The commit replaces this with `settings.root`
