### PR TITLE
fixed #1450, #1454, #1446

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_transition.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_transition.scss
@@ -122,10 +122,8 @@ $transitionable-prefixed-values: transform, transform-origin !default;
   $transitions: set-arglist-default($transitions, $default);
 
   @include with-each-prefix(css-transitions, $transition-support-threshold) {
-    $delays: ();
     $transitions-without-delays: ();
     $transitions-with-delays: ();
-    $has-delays: false;
 
 
     // This block can be made considerably simpler at the point in time that
@@ -137,32 +135,18 @@ $transitionable-prefixed-values: transform, transform-origin !default;
       $duration: if(length($transition) >= 2, nth($transition, 2), null);
       $timing-function: if(length($transition) >= 3, nth($transition, 3), null);
       $delay: if(length($transition) >= 4, nth($transition, 4), null);
-      $has-delays: $has-delays or $delay;
 
       // If a delay is provided without a timing function
       @if is-time($timing-function) and not $delay {
         $delay: $timing-function;
         $timing-function: null;
-        $has-delays: true;
       }
 
-      @if $current-prefix == -webkit {
-        // Keep a list of delays in case one is specified
-        $delays: append($delays, if($delay, $delay, 0s));
-        $transitions-without-delays: append($transitions-without-delays,
-          prefixed-for-transition($current-prefix, $property) $duration $timing-function);
-      } @else {
-        $transitions-with-delays: append($transitions-with-delays,
+      $transitions-with-delays: append($transitions-with-delays,
           prefixed-for-transition($current-prefix, $property) $duration $timing-function $delay);
-      }
     }
 
-    @if $current-prefix == -webkit {
-      @include prefix-prop(transition, $transitions-without-delays);
-      @if $has-delays {
-        @include prefix-prop(transition-delay, $delays);
-      }
-    } @else if $current-prefix {
+    @if $current-prefix {
       @include prefix-prop(transition, $transitions-with-delays);
     } @else {
       transition: $transitions-with-delays;


### PR DESCRIPTION
changed transition lists to comma-lists and removed all webkit-special code because the current Chrome does not understand it
