### PR TITLE
enabled -ms prefix in user-select mixin

### DIFF
--- a/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_user-interface.scss
@@ -12,6 +12,6 @@
 @mixin user-select($select) {
   $select: unquote($select);
   @include experimental(user-select, $select,
-    -moz, -webkit, not -o, not -ms, -khtml, official
+    -moz, -webkit, not -o, -ms, -khtml, official
   );
 }


### PR DESCRIPTION
just a minor change to enable user-select for IE10+
http://ie.microsoft.com/testdrive/HTML5/msUserSelect/
