### PR TITLE
table border: zero width's should not have units assigned

### DIFF
--- a/core/stylesheets/compass/utilities/tables/_borders.scss
+++ b/core/stylesheets/compass/utilities/tables/_borders.scss
@@ -17,22 +17,22 @@
     border: {
       right: $width solid $color;
       bottom: $width solid $color;
-      left-width: 0px;
-      top-width: 0px; };
+      left-width: 0;
+      top-width: 0; };
     &:last-child {
-      border-right-width: 0px; }
+      border-right-width: 0; }
 
     // IE8 ignores rules that are included on the same line as :last-child
     // see http://www.richardscarrott.co.uk/posts/view/ie8-last-child-bug for details
     @if support-legacy-browser(ie, "8") {
       &.last {
-        border-right-width: 0px; } } }
+        border-right-width: 0; } } }
 
   tbody, tfoot {
     tr:last-child {
       th, td {
-        border-bottom-width: 0px; } }
+        border-bottom-width: 0; } }
     @if support-legacy-browser(ie, "8") {
       tr.last {
         th, td {
-          border-bottom-width: 0px; } } } } }
+          border-bottom-width: 0; } } } } }

--- a/core/test/integrations/projects/compass/css/table.css
+++ b/core/test/integrations/projects/compass/css/table.css
@@ -1,0 +1,22 @@
+.outer-table-borders {
+  border: 2px solid black; }
+  .outer-table-borders thead th {
+    border-bottom: 2px solid black; }
+  .outer-table-borders tfoot th, .outer-table-borders tfoot td {
+    border-top: 2px solid black; }
+  .outer-table-borders th:first-child {
+    border-right: 2px solid black; }
+
+.inner-table-borders th, .inner-table-borders td {
+  border-right: 2px solid black;
+  border-bottom: 2px solid black;
+  border-left-width: 0;
+  border-top-width: 0; }
+  .inner-table-borders th:last-child, .inner-table-borders td:last-child {
+    border-right-width: 0; }
+  .inner-table-borders th.last, .inner-table-borders td.last {
+    border-right-width: 0; }
+.inner-table-borders tbody tr:last-child th, .inner-table-borders tbody tr:last-child td, .inner-table-borders tfoot tr:last-child th, .inner-table-borders tfoot tr:last-child td {
+  border-bottom-width: 0; }
+.inner-table-borders tbody tr.last th, .inner-table-borders tbody tr.last td, .inner-table-borders tfoot tr.last th, .inner-table-borders tfoot tr.last td {
+  border-bottom-width: 0; }

--- a/core/test/integrations/projects/compass/sass/table.scss
+++ b/core/test/integrations/projects/compass/sass/table.scss
@@ -1,0 +1,5 @@
+@import "project-setup";
+@import "compass/utilities/tables";
+
+.outer-table-borders { @include outer-table-borders; }
+.inner-table-borders { @include inner-table-borders; }


### PR DESCRIPTION
I failed to find a test case for this so added a test + expectation
