### PR TITLE
save_blank_files added to config options

### DIFF
--- a/cli/lib/compass/logger.rb
+++ b/cli/lib/compass/logger.rb
@@ -2,11 +2,13 @@ module Compass
 
   class Logger
 
-    DEFAULT_ACTIONS = [:directory, :exists, :remove, :create, :overwrite, :compile, :error, :identical, :warning]
+    DEFAULT_ACTIONS = [:empty, :discarded, :directory, :exists, :remove, :create, :overwrite, :compile, :error, :identical, :warning]
 
     COLORS = { :clear => 0, :red => 31, :green => 32, :yellow => 33 }
 
     ACTION_COLORS = {
+      :empty     => :yellow,
+      :discarded => :red,
       :error     => :red,
       :warning   => :yellow,
       :info      => :green,

--- a/cli/lib/compass/watcher/compiler.rb
+++ b/cli/lib/compass/watcher/compiler.rb
@@ -32,7 +32,7 @@ module Compass
     private #=========================================================================================>
 
       def create_compiler_options(additional_options)
-        compiler_opts = {:sass => Compass.sass_engine_options, :cache_store => @cache_store, :quiet => true, :loud => [:identical, :overwrite, :create]}.merge(additional_options)
+        compiler_opts = {:sass => Compass.sass_engine_options, :cache_store => @cache_store, :quiet => true, :loud => [:empty, :discarded, :identical, :overwrite, :create]}.merge(additional_options)
         compiler_opts[:cache_location] ||= determine_cache_location
         if compiler_opts.include?(:debug_info)
           compiler_opts[:sass][:debug_info] = compiler_opts.delete(:debug_info)

--- a/compass-style.org/content/help/documentation/configuration-reference.markdown
+++ b/compass-style.org/content/help/documentation/configuration-reference.markdown
@@ -316,6 +316,13 @@ later on.
       Defaults to <code> [images_path] </code>
     </td>
   </tr>
+  <tr>
+    <td style="vertical-align:top;"><code>save_blank_files</code></td>
+    <td style="vertical-align:top;">Boolean </td>
+    <td style="vertical-align:top;">
+      When compiling, this prevents the saving of empty files. Defaults to false.
+    </td>
+  </tr>
 </table>
 
 <a name="configuration-functions"></a>

--- a/core/lib/compass/configuration.rb
+++ b/core/lib/compass/configuration.rb
@@ -48,6 +48,8 @@ module Compass
     end
 
     ATTRIBUTES = [
+      # Save blank rendered files?
+      :save_blank_files,
       # What kind of project?
       :project_type,
       # Where is the project?


### PR DESCRIPTION
When using files in Sass as classes or models for mixins and variables, sometimes no content is rendered and an empty file will be saved. This is just a minor annoyance so I thought I'd provide a quick hook.
