### PR TITLE
IE7 requires html { font-size: 100%; } in establish-baseline()

### DIFF
--- a/core/stylesheets/compass/typography/_vertical_rhythm.scss
+++ b/core/stylesheets/compass/typography/_vertical_rhythm.scss
@@ -96,15 +96,15 @@ $relative-font-sizing: if($rhythm-unit == px, false, true);
 // Establishes a font baseline for the given font-size.
 @mixin establish-baseline($font-size: $base-font-size) {
   $relative-size: 100% * ($font-size / $browser-default-font-size);
-
-  @if support-legacy-browser(ie, "6") and (not $relative-font-sizing) {
-    // IE 6 refuses to resize fonts set in pixels and it weirdly resizes fonts
-    // whose root is set in ems. So we set the root font size in percentages of
-    // the default font size, even if we are using absolute sizes elsewhere.
-    * html { font-size: $relative-size; }
-  }
   html {
     font-size: if($relative-font-sizing, $relative-size, $font-size);
+
+    // IE 6/7 refuse to resize fonts set in pixels and they weirdly resize fonts
+    // whose root is set in ems. So we set the root font size in percentages of
+    // the default font size, even if we are using absolute sizes elsewhere.
+    @if support-legacy-browser(ie, "7") and (not $relative-font-sizing) {
+      *font-size: $relative-size;
+    }
 
     // Webkit has a bug that prevents line-height being set in rem on <html>;
     // To work around this and simplify output, we can set initial line-height

--- a/core/test/integrations/projects/compass/css/vertical_rhythm.css
+++ b/core/test/integrations/projects/compass/css/vertical_rhythm.css
@@ -164,6 +164,58 @@ blockquote {
 /* New using px output */
 html {
   font-size: 18px;
+  *font-size: 112.5%;
+  line-height: 25px; }
+
+.container {
+  background-image: -moz-linear-gradient(bottom, rgba(0, 0, 0, 0.5) 5%, rgba(0, 0, 0, 0) 5%);
+  background-image: -o-linear-gradient(bottom, rgba(0, 0, 0, 0.5) 5%, rgba(0, 0, 0, 0) 5%);
+  background-image: -webkit-linear-gradient(bottom, rgba(0, 0, 0, 0.5) 5%, rgba(0, 0, 0, 0) 5%);
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.5) 5%, rgba(0, 0, 0, 0) 5%);
+  -moz-background-size: 100% 25px;
+  -o-background-size: 100% 25px;
+  -webkit-background-size: 100% 25px;
+  background-size: 100% 25px;
+  background-position: left top; }
+
+p {
+  margin-top: 25px;
+  margin-bottom: 25px; }
+
+th,
+td {
+  padding-top: 6px;
+  padding-bottom: 6px; }
+
+/* Incremental leading made easy! */
+.caption {
+  font-size: 15px;
+  line-height: 20px; }
+
+.spaced-out {
+  line-height: 37px; }
+
+blockquote {
+  margin-top: 25px;
+  margin-bottom: 25px;
+  padding: 0 25px; }
+
+.fig-quote > blockquote {
+  margin-bottom: 12px; }
+.fig-quote .source {
+  font-size: 15px;
+  line-height: 25px;
+  margin-bottom: 12px; }
+
+.panel {
+  border-width: 1px;
+  border-style: solid;
+  border-color: #aaaaaa;
+  padding: 24px; }
+
+/* New using px output without IE7 support */
+html {
+  font-size: 18px;
   line-height: 25px; }
 
 .container {

--- a/core/test/integrations/projects/compass/sass/vertical_rhythm.scss
+++ b/core/test/integrations/projects/compass/sass/vertical_rhythm.scss
@@ -216,3 +216,56 @@ blockquote {
 	@include rhythm-borders;
 }
 
+
+/* New using px output without IE7 support */
+$base-font-size: 18px;
+$base-line-height: $base-font-size * 1.4;
+$rhythm-unit: px;
+$default-rhythm-border-style: solid #aaa;
+$browser-minimum-versions: ('ie': '8');
+@import "compass/typography/vertical_rhythm";
+
+@include establish-baseline;
+
+.container {
+	@include debug-vertical-alignment;
+}
+
+p {
+	@include margin-leader;
+	@include margin-trailer;
+}
+
+th,
+td {
+	@include rhythm-padding(.25);
+}
+
+/* Incremental leading made easy! */
+.caption {
+	@include adjust-font-size-to(.85rem, 4/5);
+}
+
+.spaced-out {
+	@include adjust-leading-to(1.5);
+}
+
+blockquote {
+	@include rhythm-margins;
+	padding: 0 rhythm();
+}
+
+.fig-quote {
+	> blockquote {
+		@include trailer(.5);
+	}
+	.source {
+		@include adjust-font-size-to(.85rem, auto);
+		@include trailer(.5);
+	}
+}
+
+.panel {
+	@include rhythm-borders;
+}
+


### PR DESCRIPTION
I was checking out the updated vertical-rhythm module and saw that `* html { font-size: 100%; }` is only added for IE 6. I seemed to remember that IE 7 also required that. So I looked it up…

IE 6 and 7 cannot resize fonts set with px. http://alistapart.com/article/howtosizetextincss#section3

IE 6 and 7 resize fonts weirdly when set with em. http://alistapart.com/article/howtosizetextincss#section4

Since IE7 doesn't understand the `* html` selector hack, we have to switch to the `*property` hack that both IE 6 and IE 7 know (but IE 8 and above do not.)
