### PR TITLE
Added support for the $<sprite-map>-prefix attribute.

### DIFF
--- a/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
+++ b/frameworks/compass/stylesheets/compass/utilities/sprites/_base.scss
@@ -53,10 +53,11 @@ $disable-magic-sprite-selectors:false !default;
 // If a base class is provided, then each class will extend it.
 //
 // If `$dimensions` is `true`, the sprite dimensions will specified.
+
 @mixin sprites($map, $sprite-names, $base-class: false, $dimensions: false, $prefix: sprite-map-name($map), $offset-x: 0, $offset-y: 0) {
   @each $sprite-name in $sprite-names {
     @if sprite_does_not_have_parent($map, $sprite-name) {
-      $full-sprite-name: "#{$prefix}-#{$sprite-name}";
+      $full-sprite-name: "#{$prefix}#{$sprite-name}";
       .#{$full-sprite-name} {
         @if $base-class { @extend #{$base-class}; }
         @include sprite($map, $sprite-name, $dimensions, $offset-x, $offset-y);

--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -74,7 +74,7 @@ module Compass
       Data.send(:define_method, :"default_#{name}", &default) if default
       Data.inherited_accessor(name)
       if name.to_s =~ /dir|path/
-        Data.strip_trailing_separator(name)
+        strip_trailing_separator(name)
       end
     end
 

--- a/lib/compass/sprite_importer/content.erb
+++ b/lib/compass/sprite_importer/content.erb
@@ -7,7 +7,7 @@ $<%= name %>-sprite-dimensions: false !default;
 $<%= name %>-position: 0% !default;
 $<%= name %>-spacing: 0 !default;
 $<%= name %>-repeat: no-repeat !default;
-$<%= name %>-prefix: '' !default;
+$<%= name %>-prefix: '<%= name %>-' !default;
 $<%= name %>-clean-up: true !default;
 $<%= name %>-layout:vertical !default;
 $<%= name %>-inline: false !default;
@@ -76,6 +76,6 @@ $<%= name %>-inline: false !default;
 }
 
 // Generates a class for each sprited image.
-@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: sprite-map-name($<%= name %>-sprites), $offset-x: 0, $offset-y: 0) {
+@mixin all-<%= name %>-sprites($dimensions: $<%= name %>-sprite-dimensions, $prefix: $<%= name %>-prefix, $offset-x: 0, $offset-y: 0) {
   @include <%= name %>-sprites(<%= sprite_names.join(" ") %>, $dimensions, $prefix, $offset-x, $offset-y);
 }


### PR DESCRIPTION
With the $<sprite-map>-prefix attribute the default prefix (= sprite folder name) for the generated sprite classes can be overwritten.

My use case: In some cases we use our company branded icons as single images, in other cases they are merged in sprite sheets. It's easier for everyone if file names and sprite classes are identical. So i don't want the sprite classes to be prefixed with their including folder's name. In this case I set the  $<sprite-map>-prefix to null.
(This could also be the use case for Issue https://github.com/chriseppstein/compass/issues/249)

I found the existing $<sprite-map>-prefix attribute in the original code unused. So I hijacked it for my purposes.
