### PR TITLE
Fix of listen_test access issue when calling compass watch

### DIFF
--- a/cli/lib/compass/configuration/adapters.rb
+++ b/cli/lib/compass/configuration/adapters.rb
@@ -70,19 +70,12 @@ module Compass
         Compass::Frameworks::ALL.each do |f|
           load_paths << f.stylesheets_directory if File.directory?(f.stylesheets_directory)
         end
-        importer = sass_options[:filesystem_importer] if sass_options && sass_options[:filesystem_importer]
-        importer ||= Sass::Importers::Filesystem
-        load_paths += resolve_additional_import_paths
-        load_paths.map! do |p|
-          next p if p.respond_to?(:find_relative)
-          importer.new(p.to_s)
-        end
+        load_paths = watch_load_paths(load_paths)
         load_paths << Compass::SpriteImporter.new
         load_paths
       end
 
-      def watch_load_paths
-        load_paths = []
+      def watch_load_paths(load_paths=[])
         importer = sass_options[:filesystem_importer] if sass_options && sass_options[:filesystem_importer]
         importer ||= Sass::Importers::Filesystem
         load_paths += resolve_additional_import_paths
@@ -92,6 +85,7 @@ module Compass
         end
         load_paths
       end
+
     end
     class Data
       include Adapters

--- a/cli/lib/compass/configuration/adapters.rb
+++ b/cli/lib/compass/configuration/adapters.rb
@@ -80,6 +80,18 @@ module Compass
         load_paths << Compass::SpriteImporter.new
         load_paths
       end
+
+      def watch_load_paths
+        load_paths = []
+        importer = sass_options[:filesystem_importer] if sass_options && sass_options[:filesystem_importer]
+        importer ||= Sass::Importers::Filesystem
+        load_paths += resolve_additional_import_paths
+        load_paths.map! do |p|
+          next p if p.respond_to?(:find_relative)
+          importer.new(p.to_s)
+        end
+        load_paths
+      end
     end
     class Data
       include Adapters

--- a/cli/lib/compass/watcher/project_watcher.rb
+++ b/cli/lib/compass/watcher/project_watcher.rb
@@ -46,7 +46,7 @@ module Compass
       end
 
       def directories_to_watch
-        [Compass.configuration.sass_path] + Compass.configuration.sass_load_paths.map{|p| p.respond_to?(:root) ? p.root : nil}.compact
+        [Compass.configuration.sass_path] + Compass.configuration.watch_load_paths.map{|p| p.respond_to?(:root) ? p.root : nil}.compact
       end
 
       def listen_callback(modified_files, added_files, removed_files)

--- a/cli/lib/compass/watcher/project_watcher.rb
+++ b/cli/lib/compass/watcher/project_watcher.rb
@@ -46,7 +46,25 @@ module Compass
       end
 
       def directories_to_watch
-        [Compass.configuration.sass_path] + Compass.configuration.watch_load_paths.map{|p| p.respond_to?(:root) ? p.root : nil}.compact
+        remove_redundant_directories([Compass.configuration.sass_path] + Compass.configuration.watch_load_paths.map{|p| p.respond_to?(:root) ? p.root : nil}.compact)
+      end
+
+      #blatantly copied from sass (lib/sass/plugin/compiler.rb#L327-L342)
+      #This code is going to be rewritten to use Sass watchers, so this is a short term fix
+      def remove_redundant_directories(directories)
+        dedupped = []
+        directories.each do |new_directory|
+          # no need to add a directory that is already watched.
+          next if dedupped.any? do |existing_directory|
+            child_of_directory?(existing_directory, new_directory)
+          end
+          # get rid of any sub directories of this new directory
+          dedupped.reject! do |existing_directory|
+            child_of_directory?(new_directory, existing_directory)
+          end
+          dedupped << new_directory
+        end
+        dedupped
       end
 
       def listen_callback(modified_files, added_files, removed_files)


### PR DESCRIPTION
Related to ticket #1497

The way the listener was started, it included the compass gem stylesheet directory, which is read-only for default installs, thus getting the EACCES error. 

Couldn't find any existing unit tests that involved registering a framework.  I did run existing unit tests and verified they still worked.  I also verified that I'm no longer getting the permission issue.

I don't really do ruby.  Please review.
