### PR TITLE
In support-legacy-browser(), default threshold should not override browser minimum versions

### DIFF
--- a/core/stylesheets/compass/_support.scss
+++ b/core/stylesheets/compass/_support.scss
@@ -99,12 +99,17 @@ $css-sel2-support-threshold: $critical-usage-threshold !default;
   }
   // Check agaist usage stats and declared minimums
   $min-required-version: map-get($browser-minimum-versions, $browser);
+  $supported-browser: ($min-required-version and
+                       compare-browser-versions($browser, $max-version or $min-version, $min-required-version) >= 0);
+  // If a minimum required version is specified and the default threshold is
+  // used, we only check the declared browser minimums.
+  @if ($threshold == $critical-usage-threshold) and $min-required-version {
+    @return $supported-browser;
+  }
   $usage: if($max-version,
              omitted-usage($browser, $min-version, $max-version),
              omitted-usage($browser, $min-version));
-  @return $usage > $threshold or
-          ($min-required-version and
-           compare-browser-versions($browser, $max-version or $min-version, $min-required-version) >= 0);
+  @return $usage > $threshold or $supported-browser;
 }
 
 // Include content for a legacy browser
@@ -123,17 +128,23 @@ $css-sel2-support-threshold: $critical-usage-threshold !default;
     @include with-browser-ranges(intersect-browser-ranges($current-browser-versions, $ranges)) {
       @content;
     }
-  } @else if $debug-browser-support and browser-out-of-scope($browser, $max-version) {
-    /* Content for #{display-browser-range($browser, $min-version, $max-version)} omitted.
-       Not allowed in the current scope: #{browser-out-of-scope($browser, $max-version)} */
-  } @else if $debug-browser-support and not
-             support-legacy-browser($browser, $min-version, $max-version, $threshold) {
-    @if omitted-usage($browser, $min-version, $max-version) > $threshold {
+  } @else if $debug-browser-support {
+    @if browser-out-of-scope($browser, $max-version) {
       /* Content for #{display-browser-range($browser, $min-version, $max-version)} omitted.
-         User threshold to keep: #{$threshold}%. If #{display-browser-range($browser, $min-version, $max-version)} and below are omitted: #{omitted-usage($browser, $min-version, $max-version)}%. */
-    } @else {
-      /* Content for #{display-browser-range($browser, $min-version, $max-version)} omitted.
-         Minimum support is #{map-get($browser-minimum-versions, $browser)}. */
+         Not allowed in the current scope: #{browser-out-of-scope($browser, $max-version)} */
+    } @else if not support-legacy-browser($browser, $min-version, $max-version, $threshold) {
+      // Check agaist usage stats and declared minimums
+      $min-required-version: map-get($browser-minimum-versions, $browser);
+      $usage: if($max-version,
+                 omitted-usage($browser, $min-version, $max-version),
+                 omitted-usage($browser, $min-version));
+      @if ($threshold == $critical-usage-threshold) and $min-required-version or $usage <= $threshold {
+        /* Content for #{display-browser-range($browser, $min-version, $max-version)} omitted.
+           Minimum support is #{$min-required-version}. */
+      } @else {
+        /* Content for #{display-browser-range($browser, $min-version, $max-version)} omitted.
+           User threshold to keep: #{$threshold}%. If #{display-browser-range($browser, $min-version, $max-version)} and below are omitted: #{$usage}%. */
+      }
     }
   }
 }

--- a/core/test/integrations/projects/compass/css/gradients.css
+++ b/core/test/integrations/projects/compass/css/gradients.css
@@ -303,3 +303,8 @@
   background-image: -moz-linear-gradient(#dddddd, #aaaaaa);
   background-image: -webkit-linear-gradient(#dddddd, #aaaaaa);
   background-image: linear-gradient(#dddddd, #aaaaaa); }
+
+.issue-1524-has-no-svg-because-of-minimums {
+  background-image: -moz-linear-gradient(#dddddd, #aaaaaa);
+  background-image: -webkit-linear-gradient(#dddddd, #aaaaaa);
+  background-image: linear-gradient(#dddddd, #aaaaaa); }

--- a/core/test/integrations/projects/compass/sass/gradients.sass
+++ b/core/test/integrations/projects/compass/sass/gradients.sass
@@ -179,3 +179,7 @@ $browser-minimum-versions: ('ie': '9')
 .issue-1676-has-svg-because-of-minimums
   +background-image(linear-gradient(#ddd, #aaa))
 
+$svg-gradient-shim-threshold: $critical-usage-threshold
+$browser-minimum-versions: ('ie': '10')
+.issue-1524-has-no-svg-because-of-minimums
+  +background-image(linear-gradient(#ddd, #aaa))


### PR DESCRIPTION
By default, `support-legacy-browser(ie, "7")` returns `true` because IE 7 browser usage is above the `$critical-usage-threshold`. That’s by design. Works for me!

However, if I specify `$browser-minimum-versions: ('ie': '8')`,  then `support-legacy-browser(ie, "7")` should return `false`. We are explicitly saying we want IE8 and higher only. Unfortunately, `support-legacy-browser(ie, "7")` still returns `true`.

Take this file for example: http://sassmeister.com/gist/e0aa37ca8d480d078ca5

``` scss
.test {
  @if support-legacy-browser(ie, "7") {
    content: 'ie7';
  }
  @else {
    content: 'ie8 and higher';
  }
}
```

No matter what we set `$browser-minimum-versions` to, the 'ie7' line is always output.

There's actually a few lines of CSS in compass-core that are broken because of this bug.
