### PR TITLE
Allow mixins outputting selectors to be used at the stylesheet root

### DIFF
--- a/core/stylesheets/compass/css3/_selection.scss
+++ b/core/stylesheets/compass/css3/_selection.scss
@@ -11,11 +11,9 @@ $selection-support-threshold: $graceful-usage-threshold !default;
 // during selection: color and background-color. Firefox supports the
 // text-shadow property.
 //
-// At the stylesheet root, include the mixin within the * selector.
+// At the stylesheet root, include the mixin.
 //
-//     * {
-//       @include selection(#fe57a1, #fff)
-//     }
+//     @include selection(#fe57a1, #fff)
 //
 // If a specific element or selector's selection is being styled
 // you can use that selector instead. For example:
@@ -49,7 +47,7 @@ $selection-support-threshold: $graceful-usage-threshold !default;
     @if $current-prefix != null {
       $selector: $current-prefix + '-';
     }
-    $selector: "&::#{$selector}selection";
+    $selector: if("#{&}" != '', '&', '') + "::#{$selector}selection";
     #{$selector} {
       color: $color;
       background-color: $background-color;


### PR DESCRIPTION
I was converting a CSS ruleset of:

```
::selection {
  background: #ca322c;
  color: white;
}
```

to use Compass, when I saw that the Compass mixin required a `* { }` wrapper. With Sass 3.3's `#{&}` capability, it should be possible to use any mixin that outputs a selector at the root level of the stylesheet.

Currently, doing this at the root of a stylesheet produces an error, but it shouldn't:

```
@include selection(#ca322c, white);
```
