### PR TITLE
Be more optimistic re: compatible listen gem versions.

### DIFF
--- a/cli/compass.gemspec
+++ b/cli/compass.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gemspec|
   gemspec.add_dependency 'compass-core', "~> #{File.read(File.join(File.dirname(__FILE__),"..","core","VERSION")).strip}"
   gemspec.add_dependency 'compass-import-once', "~> #{File.read(File.join(File.dirname(__FILE__),"..","import-once","VERSION")).strip}"
   gemspec.add_dependency 'chunky_png', '~> 1.2'
-  gemspec.add_dependency 'listen', '~> 1.1.0'
+  gemspec.add_dependency 'listen', '~> 1.1'
   gemspec.add_dependency 'json'
 
   gemspec.post_install_message = <<-MESSAGE


### PR DESCRIPTION
Unless you know that Compass is incompatible with newer versions of ruby gem listen, please consider being less pessimistic about its version specifier.

Leads to conflicts bundling alongside, e.g., jekyll-1.4.3
