### PR TITLE
calculate brightness() only for color values; fixes #1599

### DIFF
--- a/core/stylesheets/compass/utilities/color/_brightness.scss
+++ b/core/stylesheets/compass/utilities/color/_brightness.scss
@@ -5,8 +5,16 @@
 // a color. Brightness is sometimes called luminance.
 //
 // Returns a number between 0% and 100%, where 100% is fully bright
-// (white) and 0% is fully dark (black).
+// (white) and 0% is fully dark (black) for color values.
+//
+// For numbers and percentages it returns the same value to be used
+// in `@include filter(brightness(1.1))`.
 @function brightness($color) {
-  @return ((red($color) * .299) + (green($color) * .587) + (blue($color) * .114)) / 255 * 100%;
+  @if type-of($color) == color {
+    @return ((red($color) * .299) + (green($color) * .587) + (blue($color) * .114)) / 255 * 100%;
+  }
+  @else {
+    @return $color;
+  }
 }
 

--- a/core/test/integrations/projects/compass/css/brightness.css
+++ b/core/test/integrations/projects/compass/css/brightness.css
@@ -12,3 +12,9 @@
 
 .red-is-29-point-9-percent {
   brightness: 29.9%; }
+
+.numeric-brightness-keeps-value {
+  brightness: 1.1; }
+
+.percentage-brightness-keeps-value {
+  brightness: 110%; }

--- a/core/test/integrations/projects/compass/sass/brightness.scss
+++ b/core/test/integrations/projects/compass/sass/brightness.scss
@@ -11,3 +11,7 @@
   brightness: brightness(#0000ff); }
 .red-is-29-point-9-percent {
   brightness: brightness(#ff0000); }
+.numeric-brightness-keeps-value {
+  brightness: brightness(1.1); }
+.percentage-brightness-keeps-value {
+  brightness: brightness(110%); }


### PR DESCRIPTION
Fixed https://github.com/chriseppstein/compass/issues/1599.
