### PR TITLE
Suppress unknown vendor prefixed properties for border-radius

### DIFF
--- a/doc-src/content/help/index.haml
+++ b/doc-src/content/help/index.haml
@@ -35,7 +35,7 @@ layout: site
         compass watch
 
     Now you can edit the `*.scss` files in the `sass` directory with the text editor of your choice.
-    the `compass watch` process will automatically compile your them into css in the stylesheets directory whenever they change.
+    the `compass watch` process will automatically compile them into your css in the stylesheets directory whenever they change.
     The files in the `sass` directory are yours and you can change them, delete them, add new ones, etc.
 
     ## Manual setup using the Blueprint Framework

--- a/frameworks/compass/stylesheets/compass/css3/_border-radius.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_border-radius.scss
@@ -59,7 +59,14 @@ $default-border-radius: 5px !default;
     );
   }
   @else {
-    @include experimental(border-radius, $radius);
+    @include experimental(border-radius, $radius,
+      -moz,
+      -webkit,
+      not -o,
+      not -ms,
+      -khtml,
+      official
+    );
   }
 }
 

--- a/lib/compass/configuration.rb
+++ b/lib/compass/configuration.rb
@@ -74,7 +74,7 @@ module Compass
       Data.send(:define_method, :"default_#{name}", &default) if default
       Data.inherited_accessor(name)
       if name.to_s =~ /dir|path/
-        Data.strip_trailing_separator(name)
+        strip_trailing_separator(name)
       end
     end
 


### PR DESCRIPTION
Remove vendor prefixes for -o-border-radius and -ms-border-radius. Those properties don't exist. This is already fixed when two values are passed but not for the default behaviour.
