### PR TITLE
Using extend-only selectors for stretching examples

### DIFF
--- a/compass-style.org/content/examples/compass/layout/stretching/stylesheet.scss
+++ b/compass-style.org/content/examples/compass/layout/stretching/stylesheet.scss
@@ -10,7 +10,7 @@
   @include inline-block;
 }
 
-.stretched {
+%stretched {
   $stretch-color: #4c6b99;
   border: 3px solid $stretch-color;
   @include border-radius(8px);


### PR DESCRIPTION
I guess this is a nice place to put %placeholders to use.
As I read the example, I looked all over for a `stretched` class in the html example, but it wasn't there.
Turns out it already is a placeholder, it just doesn't use the `%` extend-only notation.
