### PR TITLE
Allow inline_image() to find image assets in bundled gem

### DIFF
--- a/core/lib/compass/core/sass_extensions/functions/inline_image.rb
+++ b/core/lib/compass/core/sass_extensions/functions/inline_image.rb
@@ -2,7 +2,7 @@ module Compass::Core::SassExtensions::Functions::InlineImage
 
   def inline_image(path, mime_type = nil)
     path = path.value
-    real_path = File.join(Compass.configuration.images_path, path)
+    real_path = image_path_for_size(path)
     inline_image_string(data(real_path), compute_mime_type(path, mime_type))
   end
 


### PR DESCRIPTION
**Note:** Rebased off of master per @scottdavis request in [pull request 1643](https://github.com/chriseppstein/compass/pull/1643). Resolves issue #1644.

Use image_path_for_size() to ask sprockets for outside asset paths if image asset is not found among application assets.

_I've locally tested this by moving an asset from the app to the gem and back. I'd like to add actual tests for this, but 1. there aren't any existing tests to update for this existing feature, 2. I'm really not sure how to test this code when an asset is being included into another project though a gem, 3. Still aspiring to earn "rubyist" cred._ =)
