### PR TITLE
Fix sprite_image relative path

### DIFF
--- a/cli/lib/compass/sass_extensions/functions/sprites.rb
+++ b/cli/lib/compass/sass_extensions/functions/sprites.rb
@@ -120,9 +120,9 @@ module Compass::SassExtensions::Functions::Sprites
     verify_map(map, "sprite")
     verify_sprite(sprite)
     if image = map.image_for(sprite.value)
-      image_path = Pathname.new(File.expand_path(image.file, Compass.configuration.images_path))
-      generated_images_path = Pathname.new(Compass.configuration.generated_images_path)
-      quoted_string(image_path.relative_path_from(generated_images_path).to_s)
+      image_path = Pathname.new(File.expand_path(image.file))
+      images_path = Pathname.new(Compass.configuration.images_path)
+      quoted_string(image_path.relative_path_from(images_path).to_s)
     else
       missing_image!(map, sprite)
     end


### PR DESCRIPTION
I was having some trouble with sprite paths with a pretty uncommon directory and path configuration for my images and sprites. My generated sprites are placed in a directory inside the images path, not the image path itself, so when the relative path returned by the `sprite_image` method was build, it went over an extra directory before searching the original sprite image.

I'm not really a ruby guy, so I don't know if something went missing, though it's working for me on quite many different configurations I've tried before patching.

Just in case, I'm placing my _config.rb_ settings at the time I had the problems, so anyone can replicate the error too:

```
relative_assets       = true
sass_dir              = "source"
css_dir               = "../css"
images_dir            = "../images"
generated_images_dir  = "../images/sprites"
sprite_load_path      = "sprites"
```

If you change the `generated_images_dir` to "../images" you will see it starts working. Odd.

Hope I can help ;)
