### PR TITLE
Fixes output in transition mixing when giving parameters in any order

### DIFF
--- a/core/stylesheets/compass/css3/_transition.scss
+++ b/core/stylesheets/compass/css3/_transition.scss
@@ -56,6 +56,27 @@ $transitionable-prefixed-values: transform, transform-origin !default;
   }
 }
 
+// Returns $transition-map which includes key and values that map to a transition declaration
+@function transition-map($transition) {
+  $transition-map: ();
+
+  @each $item in $transition {
+    @if is-time($item) {
+      @if map-has-key($transition-map, duration) {
+        $transition-map: map-merge($transition-map, (delay: $item));
+      } @else {
+        $transition-map: map-merge($transition-map, (duration: $item));
+      }
+    } @else if map-has-key($transition-map, property) {
+      $transition-map: map-merge($transition-map, (timing-function: $item));
+    } @else {
+      $transition-map: map-merge($transition-map, (property: $item));
+    }
+  }
+
+  @return $transition-map;
+}
+
 // One or more properties to transition
 //
 // * for multiple, use a comma-delimited list
@@ -133,20 +154,16 @@ $transitionable-prefixed-values: transform, transform-origin !default;
     // This block can be made considerably simpler at the point in time that
     // we no longer need to deal with the differences in how delays are treated.
     @each $transition in $transitions {
-      // Extract the values from the list
-      // (this would be cleaner if nth took a 3rd argument to provide a default value).
-      $property: nth($transition, 1);
-      $duration: if(length($transition) >= 2, nth($transition, 2), null);
-      $timing-function: if(length($transition) >= 3, nth($transition, 3), null);
-      $delay: if(length($transition) >= 4, nth($transition, 4), null);
-      $has-delays: $has-delays or $delay;
+      // Declare initial values for transition
+      $transition: transition-map($transition);
 
-      // If a delay is provided without a timing function
-      @if is-time($timing-function) and not $delay {
-        $delay: $timing-function;
-        $timing-function: null;
-        $has-delays: true;
-      }
+      $property: map-get($transition, property);
+      $duration: map-get($transition, duration);
+      $timing-function: map-get($transition, timing-function);
+      $delay: map-get($transition, delay);
+
+      // Parse transition string to assign values into correct variables
+      $has-delays: $has-delays or $delay;
 
       @if $current-prefix == -webkit {
         // Keep a list of delays in case one is specified

--- a/core/test/integrations/projects/compass/css/transition.css
+++ b/core/test/integrations/projects/compass/css/transition.css
@@ -48,6 +48,13 @@
   -webkit-transition: -webkit-transform 0.6s ease-out, opacity 0.2s ease-in;
   transition: transform 0.6s ease-out, opacity 0.2s ease-in; }
 
+.multiple-transitions-with-params-in-random-order {
+  -moz-transition: -moz-transform 0.6s ease-out, opacity 0.2s ease-in 0.5s, color 0.4s ease-in 0.5s;
+  -o-transition: -o-transform 0.6s ease-out, opacity 0.2s ease-in 0.5s, color 0.4s ease-in 0.5s;
+  -webkit-transition: -webkit-transform 0.6s ease-out, opacity 0.2s ease-in, color 0.4s ease-in;
+  -webkit-transition-delay: 0s, 0.5s, 0.5s;
+  transition: transform 0.6s ease-out, opacity 0.2s ease-in 0.5s, color 0.4s ease-in 0.5s; }
+
 .transition-property {
   -moz-transition-property: -moz-transform;
   -o-transition-property: -o-transform;

--- a/core/test/integrations/projects/compass/sass/transition.scss
+++ b/core/test/integrations/projects/compass/sass/transition.scss
@@ -9,6 +9,7 @@
 .single-transform-transition-with-delay     { @include single-transition(transform, 0.6s, ease-out, 0.2s); }
 .transform-transition { @include transition(transform 0.6s ease-out) }
 .multiple-transitions { @include transition(transform 0.6s ease-out, opacity 0.2s ease-in) }
+.multiple-transitions-with-params-in-random-order { @include transition(0.6s transform ease-out, 0.2s ease-in opacity 0.5s, ease-in color 0.4s 0.5s) }
 .transition-property { @include transition-property(transform); }
 .transition-properties { @include transition-property(transform, opacity, width, height, left, top); }
 .multiple-transition-properties { @include transition-property((opacity, transform, left)); }


### PR DESCRIPTION
In the issue #1550 it was reported that the transition mixing did not handle the parameters right when they were not provided in the following order:

``` scss
@include transition([<property> <duration> <timing-function> <delay>]);
```

In order to have the same behavior as the definition of the transition rule by the W3C we should be able to accept the parameters in any order but it is important to remember that _"the first value that can be parsed as a time is assigned to the transition-duration, and the second value that can be parsed as a time is assigned to transition-delay."_

Reference:
[W3C transitions definition](http://www.w3.org/TR/css3-transitions/#transition-shorthand-property)
