### PR TITLE
Update install.haml

### DIFF
--- a/doc-src/content/install.haml
+++ b/doc-src/content/install.haml
@@ -53,8 +53,8 @@ body_id: install
   using
   %input#sassdir(placeholder="sass")
   for the sass source directory,
-  %input#cssdir(placeholder="css")
-  for the css output directory,
+  %input#cssdir(placeholder="stylesheets")
+  for the stylesheets output directory,
   %input#jsdir(placeholder="javascripts")
   for the javascripts directory,
   and


### PR DESCRIPTION
``` bash
$ compass create myproject
```

Outputs

```
directory myproject/
directory myproject/sass/
directory myproject/stylesheets/
   create myproject/config.rb
   create myproject/sass/screen.scss
   create myproject/sass/print.scss
   create myproject/sass/ie.scss
   create myproject/stylesheets/print.css
   create myproject/stylesheets/screen.css
   create myproject/stylesheets/ie.css
```

So, the install guide should not read that `css` will be the default CSS output directory when in fact `stylesheets` is the default CSS output directory.
