### PR TITLE
Update browser_support.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ unless ENV['PKG']
   gem "rails", "~> 3.1"
   gem "compass-validator", "3.0.1"
   gem "css_parser", "~> 1.0.1"
-  gem "sass", "3.2.19" unless defined?(CI)
+  gem "sass", "3.3.7" unless defined?(CI)
   gem "haml", "~> 3.1"
   gem "rubyzip"
   gem 'mocha'

--- a/lib/compass/sass_extensions/monkey_patches/browser_support.rb
+++ b/lib/compass/sass_extensions/monkey_patches/browser_support.rb
@@ -1,6 +1,6 @@
-require 'sass/script/node'
-require 'sass/script/literal'
-require 'sass/script/funcall'
+require 'sass/script/tree/node'
+require 'sass/script/tree/literal'
+require 'sass/script/tree/funcall'
 
 module Sass::Script
   module HasSimpleCrossBrowserFunctionSupport


### PR DESCRIPTION
Fix imports to support sass 3.3.7.

This was needed since sass 3.3.\* supports [new syntax](https://github.com/nex3/sass/issues/286).
