### PR TITLE
$legacy-support-for-mozilla, IE legacy inline-block

### DIFF
--- a/frameworks/compass/stylesheets/compass/_support.scss
+++ b/frameworks/compass/stylesheets/compass/_support.scss
@@ -18,7 +18,7 @@ $legacy-support-for-ie: $legacy-support-for-ie6 or $legacy-support-for-ie7 or $l
 
 // Whether to output legacy support for mozilla.
 // Usually this means hacks to support Firefox 3.6 or earlier.
-$legacy-support-for-mozilla: true;
+$legacy-support-for-mozilla: true !default;
 
 // Support for mozilla in experimental css3 properties (-moz).
 $experimental-support-for-mozilla      : true !default;

--- a/frameworks/compass/stylesheets/compass/css3/_inline-block.scss
+++ b/frameworks/compass/stylesheets/compass/css3/_inline-block.scss
@@ -14,8 +14,7 @@ $inline-block-alignment: middle !default;
   @if $alignment and $alignment != none {
     vertical-align: $alignment;
   }
-  @if $legacy-support-for-ie {
-    *vertical-align: auto;
+  @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
     zoom: 1;
     *display: inline;
   }


### PR DESCRIPTION
*Adds !default flag to $legacy-support-for-mozilla.
*Scopes inline-block legacy output for only IE6 & IE7, and removes the <IE7 vertical-align:auto default hack.

Closes GH-1114 and GH-1699.
