### PR TITLE
Update to minitest 5

### DIFF
--- a/test/integrations/compass_test.rb
+++ b/test/integrations/compass_test.rb
@@ -4,7 +4,7 @@ require 'compass'
 require 'compass/logger'
 require 'sass/plugin'
 
-class CompassTest < Test::Unit::TestCase
+class CompassTest < MiniTest::Test
 
   def setup
     Compass.reset_configuration!

--- a/test/integrations/sprites_test.rb
+++ b/test/integrations/sprites_test.rb
@@ -5,7 +5,7 @@ require 'compass/logger'
 require 'sass/plugin'
 
 
-class SpritesTest < Test::Unit::TestCase
+class SpritesTest < MiniTest::Test
   
   def setup
     Compass.reset_configuration!
@@ -95,7 +95,7 @@ class SpritesTest < Test::Unit::TestCase
       @import "squares/*.png";
       @include all-squares-sprites;
     SCSS
-    assert_not_nil Dir.glob("#{@generated_images_tmp_path}/squares-s*.png").first
+    refute_nil Dir.glob("#{@generated_images_tmp_path}/squares-s*.png").first
     assert_correct <<-CSS, css
       .squares-sprite, .squares-ten-by-ten, .squares-twenty-by-twenty {
         background: url('/images/generated/squares-sbbc18e2129.png') no-repeat;
@@ -420,21 +420,21 @@ class SpritesTest < Test::Unit::TestCase
   end
 
   it "should provide a nice errors for lemonade's old users" do
-    assert_raise(Sass::SyntaxError) do
+    assert_raises(Sass::SyntaxError) do
       render <<-SCSS
         .squares {
           background: sprite-url("squares/*.png") no-repeat;
         }
       SCSS
     end
-    assert_raise(Sass::SyntaxError) do
+    assert_raises(Sass::SyntaxError) do
       css = render <<-SCSS
         .squares {
           background: sprite-image("squares/twenty-by-twenty.png") no-repeat;
         }
       SCSS
     end
-    assert_raise(Sass::SyntaxError) do
+    assert_raises(Sass::SyntaxError) do
       css = render <<-SCSS
         @import "squares/*.png";
 
@@ -610,7 +610,7 @@ class SpritesTest < Test::Unit::TestCase
   end
   
   it "should raise error on filenames that are not valid sass syntax" do
-    assert_raise(Compass::Error) do
+    assert_raises(Compass::Error) do
       css = render <<-SCSS
         @import "prefix/*.png";
         a {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,8 +20,8 @@ require 'rubygems' if need_gems
 
 require 'compass'
 
-require 'test/unit'
-require "mocha/test_unit"
+require 'minitest/autorun'
+#require "mocha/test_unit"
 
 
 class String
@@ -35,7 +35,7 @@ end
 end
 
 
-class Test::Unit::TestCase
+class MiniTest::Test
   include Compass::Diff
   include Compass::TestCaseHelper
   include Compass::IoHelper

--- a/test/units/actions_test.rb
+++ b/test/units/actions_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'compass'
 
-class ActionsTest < Test::Unit::TestCase
+class ActionsTest < MiniTest::Test
   class BaseActionExtender
     include Compass::Actions
     def options

--- a/test/units/command_line_test.rb
+++ b/test/units/command_line_test.rb
@@ -4,7 +4,7 @@ require 'compass'
 require 'compass/exec'
 require 'timeout'
 
-class CommandLineTest < Test::Unit::TestCase
+class CommandLineTest < MiniTest::Test
   include Compass::TestCaseHelper
   include Compass::CommandLineHelper
   include Compass::IoHelper

--- a/test/units/compass_module_test.rb
+++ b/test/units/compass_module_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class CompassModuleTest < Test::Unit::TestCase
+class CompassModuleTest < MiniTest::Test
 
   def setup
     Compass.reset_configuration!

--- a/test/units/compass_png_test.rb
+++ b/test/units/compass_png_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'fileutils'
 
-class CompassPngTest < Test::Unit::TestCase
+class CompassPngTest < MiniTest::Test
   
   def test_class_crc_table  
     assert_equal 256, Compass::PNG::CRC_TABLE.length 

--- a/test/units/compiler_test.rb
+++ b/test/units/compiler_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'fileutils'
 
-class CompilerTest < Test::Unit::TestCase
+class CompilerTest < MiniTest::Test
   
   it "should strip css from file name and reappend" do
     compiler = Compass::Compiler.new(Dir.pwd, 'foo', 'bar', {})

--- a/test/units/configuration_test.rb
+++ b/test/units/configuration_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'compass'
 require 'stringio'
 
-class ConfigurationTest < Test::Unit::TestCase
+class ConfigurationTest < MiniTest::Test
 
   setup do
     Compass.reset_configuration!

--- a/test/units/regressions_test.rb
+++ b/test/units/regressions_test.rb
@@ -3,7 +3,7 @@ require 'compass'
 require 'compass/exec'
 require 'stringio'
 
-class RegressionsTest < Test::Unit::TestCase
+class RegressionsTest < MiniTest::Test
   include Compass::CommandLineHelper
   setup do
     Compass.reset_configuration!

--- a/test/units/sass_extensions_test.rb
+++ b/test/units/sass_extensions_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SassExtensionsTest < Test::Unit::TestCase
+class SassExtensionsTest < MiniTest::Test
   def test_simple
     assert_equal "a b", evaluate(%Q{nest("a", "b")})
   end

--- a/test/units/sprites/engine_test.rb
+++ b/test/units/sprites/engine_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EngineTest < Test::Unit::TestCase
+class EngineTest < MiniTest::Test
   include SpriteHelper
   def setup
     create_sprite_temp

--- a/test/units/sprites/image_row_test.rb
+++ b/test/units/sprites/image_row_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ImageRowTest < Test::Unit::TestCase
+class ImageRowTest < MiniTest::Test
   include SpriteHelper
   def setup
     clean_up_sprites

--- a/test/units/sprites/image_test.rb
+++ b/test/units/sprites/image_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'mocha'
 require 'ostruct'
 
-class SpritesImageTest < Test::Unit::TestCase
+class SpritesImageTest < MiniTest::Test
   include SpriteHelper
 
   def setup
@@ -57,7 +57,7 @@ class SpritesImageTest < Test::Unit::TestCase
   end
   
   test 'image type is "global" should raise exception' do
-    assert_raise ::Compass::SpriteException do
+    assert_raises ::Compass::SpriteException do
       image = test_image "selectors_ten_by_ten_repeat" => Sass::Script::String.new('global')
       image.repeat
     end

--- a/test/units/sprites/importer_test.rb
+++ b/test/units/sprites/importer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ImporterTest < Test::Unit::TestCase
+class ImporterTest < MiniTest::Test
   include SpriteHelper
   
   def setup

--- a/test/units/sprites/layout_test.rb
+++ b/test/units/sprites/layout_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LayoutTest < Test::Unit::TestCase
+class LayoutTest < MiniTest::Test
   include SpriteHelper
 
   def setup

--- a/test/units/sprites/row_fitter_test.rb
+++ b/test/units/sprites/row_fitter_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'compass/sass_extensions/sprites/row_fitter'
 
-class RowFitterTest < Test::Unit::TestCase
+class RowFitterTest < MiniTest::Test
   include SpriteHelper
   def setup
     file = StringIO.new("images_path = #{@images_src_path.inspect}\n")

--- a/test/units/sprites/sprite_command_test.rb
+++ b/test/units/sprites/sprite_command_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 require 'compass/exec'
-class SpriteCommandTest < Test::Unit::TestCase
+class SpriteCommandTest < MiniTest::Test
   include Compass::TestCaseHelper
   include Compass::CommandLineHelper
   include Compass::IoHelper

--- a/test/units/sprites/sprite_map_test.rb
+++ b/test/units/sprites/sprite_map_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SpriteMapTest < Test::Unit::TestCase
+class SpriteMapTest < MiniTest::Test
   include SpriteHelper
   
   def setup


### PR DESCRIPTION
Greetings, we're looking to fix some packages in Fedora the were broken by a recent update to minitest (now at 5.3.1).

compass was one of the gems that was broken due to it's dependency on the old API.

http://koji.fedoraproject.org/koji/packageinfo?packageID=10224

I went through and patched the source to work against the new API and am sending a PR for hopeful inclusion upstream.

Thank you for your time.
