### PR TITLE
Fixes #1600 - Invalid path returned by sprite_file

### DIFF
--- a/cli/lib/compass/sass_extensions/functions/sprites.rb
+++ b/cli/lib/compass/sass_extensions/functions/sprites.rb
@@ -120,9 +120,9 @@ module Compass::SassExtensions::Functions::Sprites
     verify_map(map, "sprite")
     verify_sprite(sprite)
     if image = map.image_for(sprite.value)
-      image_path = Pathname.new(File.expand_path(image.file, Compass.configuration.images_path))
-      generated_images_path = Pathname.new(File.expand_path(Compass.configuration.generated_images_path))
-      quoted_string(image_path.relative_path_from(generated_images_path).to_s)
+      image_path = Pathname.new(File.expand_path(image.file))
+      images_path = Pathname.new(File.expand_path(Compass.configuration.images_path))
+      quoted_string(image_path.relative_path_from(images_path).to_s)
     else
       missing_image!(map, sprite)
     end


### PR DESCRIPTION
When specifiying a generic_images_dir sprite_file would return the wrong
path to the original image because this was relative to the generic_
images_path instead of the images_path.

This should fix all problems related also to: #1617 and #1665
