### PR TITLE
WOFF2 support for font-files

### DIFF
--- a/cli/test/units/sass_extensions_test.rb
+++ b/cli/test/units/sass_extensions_test.rb
@@ -136,7 +136,7 @@ WARNING
 
   def test_font_files
     assert_equal '', evaluate('font_files()')
-    assert_equal "url(/font/name.woff) format('woff'), url(/fonts/name.ttf) format('truetype'), url(/fonts/name.svg#fontpath) format('svg')", evaluate("font-files('/font/name.woff', woff, '/fonts/name.ttf', truetype, '/fonts/name.svg#fontpath', svg)")
+    assert_equal "url(/font/name.woff) format('woff'), url(/font/name.woff2) format('woff2'), url(/fonts/name.ttf) format('truetype'), url(/fonts/name.svg#fontpath) format('svg')", evaluate("font-files('/font/name.woff', woff, '/font/name.woff2', woff2, '/fonts/name.ttf', truetype, '/fonts/name.svg#fontpath', svg)")
 
     assert_equal "url(/font/with/right_ext.woff) format('woff')", evaluate("font_files('/font/with/right_ext.woff')")
     assert_equal "url(/font/with/wrong_ext.woff) format('svg')", evaluate("font_files('/font/with/wrong_ext.woff', 'svg')")

--- a/core/lib/compass/core/sass_extensions/functions/font_files.rb
+++ b/core/lib/compass/core/sass_extensions/functions/font_files.rb
@@ -1,6 +1,7 @@
 module Compass::Core::SassExtensions::Functions::FontFiles
   FONT_TYPES = {
     :woff => 'woff',
+    :woff2 => 'woff2',
     :otf => 'opentype',
     :opentype => 'opentype',
     :ttf => 'truetype',


### PR DESCRIPTION
As of now, the function [`font-files()`](http://compass-style.org/reference/compass/helpers/font-files/) is unable to determine the font type of [WOFF2](https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a) font files, which simply is `woff2`.
