### PR TITLE
Remove .sass-cache after creating project

### DIFF
--- a/cli/lib/compass/commands/stamp_pattern.rb
+++ b/cli/lib/compass/commands/stamp_pattern.rb
@@ -73,6 +73,7 @@ Options:
       def perform
         installer.init
         installer.run(:skip_finalization => true, :skip_preparation => !is_project_creation?)
+        Compass.configuration.cache_path = options[:cache_location] || File.join(working_path, ".sass-cache")
         UpdateProject.new(working_path, options).perform if installer.compilation_required?
         installer.finalize(options.merge(:create => is_project_creation?))
       end


### PR DESCRIPTION
When compass create a new project, it'll compile this project first. At that time, however, the cache_path is point to `#{working directory}/.sass-cache`, not `#{project_path}/.sass-cache`. So I simply remove cache folder after creating project.
