### PR TITLE
Adding an AppVeyor configuration file to run Windows CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+init:
+  - git config --global core.autocrlf input
+
+clone_folder: c:\projects\compass
+
+version: "{build}"
+
+# list some environment info + install bundler
+install:
+  - ps: Get-Date
+  - ps: $env:Path = $env:RUBYPATH + "\bin;" + $env:Path
+  - ruby -v
+  - gem -v
+  - gem install bundler
+  - gem list bundler
+
+# any building is done during test using rake
+build: off
+
+test_script:
+  - ps: Write-Host "Getting ready to test core" -ForegroundColor Magenta
+  - cd C:\projects\compass\core 
+  - bundle install --quiet --jobs 2
+  - bundle exec rake test
+  - ps: Write-Host "Getting ready to test cli" -ForegroundColor Magenta
+  - cd C:\projects\compass\cli
+  - bundle install --quiet --jobs 2
+  - bundle exec rake
+  - ps: Write-Host "Getting ready to test import-once" -ForegroundColor Magenta
+  - cd C:\projects\compass\import-once
+  - bundle install --quiet --jobs 2
+  - bundle exec rake
+  - ps: Write-Host "Getting ready to test import-once with Gemfile_sass_3_2" -ForegroundColor Magenta
+  - cd C:\projects\compass\import-once
+  - SET BUNDLE_GEMFILE=Gemfile_sass_3_2
+  - bundle install --quiet --gemfile Gemfile_sass_3_2 --jobs 4
+  - bundle exec rake test
+
+after_test:
+  - ps: Get-Date
+
+on_success:
+  - ps: Write-Host "Done testing (SUCCESS)" -ForegroundColor Green
+  
+on_failure:
+  - ps: Write-Host "Done testing (FAILURE)" -ForegroundColor Red
+
+environment:
+
+  matrix:
+  - myEnv: ruby193x86
+    RUBYPATH: C:\Ruby193
+  
+  - myEnv: ruby200x86
+    RUBYPATH: C:\Ruby200
+  
+  - myEnv: ruby200x64
+    RUBYPATH: C:\Ruby200-x64
+
+matrix:
+  fast_finish: false


### PR DESCRIPTION
AppVeyor is a Windows CI solution that provides a [free service](http://www.appveyor.com/pricing) for open source projects; this sets up for using this service. Appveyor doesn't provide the extensive buildmatrix that Travis-CI provides (1.9.3 and 2.0.0 with x86 arch and 2.0.0 with x64 arch), but it does provide access to the Windows platform which Travis doesn't.

It will also do [various notifications](http://www.appveyor.com/docs/notifications) (which I haven't set up now to prevent spamming)
The dashboard looks like this for my fork: https://ci.appveyor.com/project/mprins/compass

To get this going on the Compass repo you'd need to:
- login at https://ci.appveyor.com/signup/free using your Github account
- use the "+ new project" on top of the page to select and add the Compass project
- merge this PR

This replaces #1783

Related to this is the possibility to display the build status of both Travis-CI and AppVeyor on PR's using the service provided by @astrofrog running here: http://github-multi-status.herokuapp.com/
