### PR TITLE
Register only directories while discovering extensions

### DIFF
--- a/core/lib/compass/frameworks.rb
+++ b/core/lib/compass/frameworks.rb
@@ -84,7 +84,9 @@ module Compass
       frameworks_directory = Dir.new(frameworks_directory) unless frameworks_directory.is_a?(Dir)
       dirs = frameworks_directory.entries.reject{|e| e =~ /^\./}.sort_by{|n| n =~ /^_/ ? n[1..-1] : n}
       dirs.each do |framework|
-        register_directory File.join(frameworks_directory.path, framework)
+        if File.directory?(framework)
+          register_directory File.join(frameworks_directory.path, framework)
+        end
       end
     end
 


### PR DESCRIPTION
In my _config.rb_ I have configured an `extension_dir` that is a directory that contains, besides the extensions folders, a _README.md_ file. This was causing Compass to through the following error when compiling:

```
Errno::ENOTDIR on line ["670"] of ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/util.rb: Not a directory - [PATH TO PROJECT]/extensions/README.md/stylesheets
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/util.rb:670:in `realpath'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/util.rb:670:in `realpath'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/importers/filesystem.rb:16:in `initialize'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/engine.rb:192:in `new'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/engine.rb:192:in `block in normalize_options'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/engine.rb:190:in `map'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/engine.rb:190:in `normalize_options'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/plugin/staleness_checker.rb:52:in `initialize'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/plugin/compiler.rb:203:in `new'
  ~.rvm/gems/ruby-1.9.3-p448/gems/sass-3.4.2/lib/sass/plugin/compiler.rb:203:in `update_stylesheets'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/lib/compass/sass_compiler.rb:40:in `compile!'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/lib/compass/commands/update_project.rb:49:in `perform'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/lib/compass/commands/base.rb:18:in `execute'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/lib/compass/commands/project_base.rb:19:in `execute'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/lib/compass/exec/sub_command_ui.rb:43:in `perform!'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/lib/compass/exec/sub_command_ui.rb:15:in `run!'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/bin/compass:30:in `block in <top (required)>'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/bin/compass:44:in `call'
  ~.rvm/gems/ruby-1.9.3-p448/gems/compass-1.0.1/bin/compass:44:in `<top (required)>'
  ~.rvm/gems/ruby-1.9.3-p448/bin/compass:23:in `load'
  ~.rvm/gems/ruby-1.9.3-p448/bin/compass:23:in `<main>'
  ~.rvm/gems/ruby-1.9.3-p448/bin/ruby_executable_hooks:15:in `eval'
  ~.rvm/gems/ruby-1.9.3-p448/bin/ruby_executable_hooks:15:in `<main>'
```

What seams to be happening is that Compass is trying to read all content of the extensions directory as an extension, while it should be analysing only sub-directories as extensions.

This pull request means to solve this issue.

I have to say I'm no Ruby developer, and while this is not hard to solve I think there might be a better (or more "rubish") way to do it.
