### PR TITLE
Make sure a `load_path` actually exists before creating an importer.

### DIFF
--- a/core/lib/compass/configuration/adapters.rb
+++ b/core/lib/compass/configuration/adapters.rb
@@ -88,8 +88,8 @@ module Compass
         load_paths += resolve_additional_import_paths
         load_paths.map! do |p|
           next p if p.respond_to?(:find_relative)
-          importer.new(p.to_s)
-        end
+          importer.new(p.to_s) if File.exist?(p.to_s)
+        end.compact!
         # TODO: When sprites are extracted to their own plugin, this
         # TODO: will need to be extracted to there.
         if defined?(Compass::SpriteImporter.new)


### PR DESCRIPTION
In updating Middleman to support Compass v1, I've run across this "regression."

Basically, if a project is using Compass, but doesn't have a `sass_dir` that exists, Sass explodes trying to blindly read a path that doesn't exist.

Our use-case is this: we bundle Compass with Middleman, but not everyone actually uses a specific sass directory. Rather, they embed Sass in templates directly.

I think the actual regression is in Sass, which shouldn't try to use an importer that is pointing to a missing folder.

What do you think? Basically the importer should be omitted before passing to Sass, so maybe it's correct to patch it here.
