### PR TITLE
Fixes #950 - Remove mozilla ellipsis hack

### DIFF
--- a/cli/test/fixtures/stylesheets/compass/css/utilities.css
+++ b/cli/test/fixtures/stylesheets/compass/css/utilities.css
@@ -56,16 +56,7 @@ tfoot th, tfoot td {
     background-color: yellow; }
 
 p.ellipsis {
-  white-space: nowrap;
-  overflow: hidden;
-  -ms-text-overflow: ellipsis;
-  -o-text-overflow: ellipsis;
-  text-overflow: ellipsis; }
-
-p.ellipsis.moz {
-  white-space: nowrap;
-  overflow: hidden;
-  -ms-text-overflow: ellipsis;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
-  -moz-binding: url('/tmp/xml/ellipsis.xml#ellipsis'); }
+  overflow: hidden;
+  white-space: nowrap; }

--- a/cli/test/fixtures/stylesheets/compass/sass/utilities.scss
+++ b/cli/test/fixtures/stylesheets/compass/sass/utilities.scss
@@ -25,9 +25,3 @@ p.dark-with-args  { @include contrasted(#a22321, blue, yellow); }
 p.ellipsis {
   @include ellipsis;
 }
-
-p.ellipsis.moz {
-  $legacy-support-for-mozilla: true !global;
-  $use-mozilla-ellipsis-binding: true !global;
-  @include ellipsis;
-}

--- a/compass-style.org/.gitignore
+++ b/compass-style.org/.gitignore
@@ -6,3 +6,4 @@ crash.log
 tmp
 .bundle
 .rvmrc
+.sass-cache

--- a/compass-style.org/content/reference/compass/typography/text/ellipsis.haml
+++ b/compass-style.org/content/reference/compass/typography/text/ellipsis.haml
@@ -1,4 +1,4 @@
---- 
+---
 title: Truncating Text with Ellipses
 crumb: Ellipsis
 framework: compass
@@ -10,9 +10,4 @@ classnames:
   - core
   - typography
 ---
-- render 'reference' do
-  :markdown
-    There is an XML file that must be installed into your stylesheet
-    directory in order for this utility to work correctly. To install it:
-    
-        compass install compass/ellipsis
+= render 'reference'

--- a/compass-style.org/content/stylesheets/screen.scss
+++ b/compass-style.org/content/stylesheets/screen.scss
@@ -38,6 +38,3 @@ blockquote {
   @extend code;
 }
 
-#page h3 {
-  padding-left: 0;
-}

--- a/core/stylesheets/compass/typography/text/_ellipsis.scss
+++ b/core/stylesheets/compass/typography/text/_ellipsis.scss
@@ -1,25 +1,14 @@
-@import "compass/css3/deprecated-support";
+@import "compass/support";
 
-// To get full firefox support, you must install the ellipsis pattern:
-//
-//     compass install compass/ellipsis
-$use-mozilla-ellipsis-binding: false !default;
+$ellipsis-threshold: $graceful-usage-threshold !default;
 
 // This technique, by [Justin Maxwell](http://code404.com/), was originally
 // published [here](http://mattsnider.com/css/css-string-truncation-with-ellipsis/).
 // Firefox implementation by [Rikkert Koppes](http://www.rikkertkoppes.com/thoughts/2008/6/).
 @mixin ellipsis($no-wrap: true) {
-  @if $no-wrap { white-space: nowrap; }
-  overflow: hidden;
-  @include experimental(text-overflow, ellipsis,
-    not -moz,
-    not -webkit,
-    -o,
-    -ms,
-    not -khtml,
-    official
-  );
-  @if $legacy-support-for-mozilla and $use-mozilla-ellipsis-binding {
-    -moz-binding: stylesheet-url(unquote("xml/ellipsis.xml#ellipsis"));
+  @include with-each-prefix(text-overflow, $ellipsis-threshold) {
+    @include prefix-prop("text-overflow", ellipsis);
   }
+  overflow: hidden;
+  @if $no-wrap { white-space: nowrap; }
 }

--- a/core/test/integrations/projects/compass/css/utilities.css
+++ b/core/test/integrations/projects/compass/css/utilities.css
@@ -56,16 +56,7 @@ tfoot th, tfoot td {
     background-color: yellow; }
 
 p.ellipsis {
-  white-space: nowrap;
-  overflow: hidden;
-  -ms-text-overflow: ellipsis;
-  -o-text-overflow: ellipsis;
-  text-overflow: ellipsis; }
-
-p.ellipsis.moz {
-  white-space: nowrap;
-  overflow: hidden;
-  -ms-text-overflow: ellipsis;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
-  -moz-binding: url('/tmp/xml/ellipsis.xml#ellipsis'); }
+  overflow: hidden;
+  white-space: nowrap; }

--- a/core/test/integrations/projects/compass/sass/utilities.scss
+++ b/core/test/integrations/projects/compass/sass/utilities.scss
@@ -23,9 +23,3 @@ p.dark-with-args  { @include contrasted(#a22321, blue, yellow); }
 p.ellipsis {
   @include ellipsis;
 }
-
-p.ellipsis.moz {
-  $legacy-support-for-mozilla: true !global;
-  $use-mozilla-ellipsis-binding: true !global;
-  @include ellipsis;
-}


### PR DESCRIPTION
As mentioned in #950 - [Firefox 4 disabled XUL for websites](https://groups.google.com/forum/?fromgroups#!topic/mozilla.dev.platform/MnnmjYlm2jY) so the hack that we had for ellipsis in old firefox versions was not working. 
