### PR TITLE
Fixed Configuration Reference URL

### DIFF
--- a/compass-style.org/content/help/tutorials/production-css.markdown
+++ b/compass-style.org/content/help/tutorials/production-css.markdown
@@ -7,7 +7,7 @@ classnames:
 Production Stylesheets
 ======================
 
-See the [Configuration Reference](/help/tutorials/configuration-reference/) for a
+See the [Configuration Reference](/help/documentation/configuration-reference/) for a
 complete list of available configuration options.
 
 Strategies for Compiling Stylesheets for Production


### PR DESCRIPTION
404 for /help/tutorials/configuration-reference/
Linking here now : /help/documentation/configuration-reference/
