### PR TITLE
Add related values to user-select mixin

### DIFF
--- a/core/stylesheets/compass/css3/_user-interface.scss
+++ b/core/stylesheets/compass/css3/_user-interface.scss
@@ -16,6 +16,12 @@ $userselect-support-threshold: $graceful-usage-threshold !default;
 @mixin user-select($select) {
   $select: unquote($select);
 
+  // Controls behavior of the callout and highlight color on iOS and Android devices.
+  @if $select == none {
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
+    -webkit-touch-callout: none;
+  }
+
   @include with-each-prefix(user-select-none, $userselect-support-threshold) {
     // old Firefox used a proprietary `-moz-none` value, starting with Firefox 21 `none` behaves like `-moz-none`
     // @link https://developer.mozilla.org/en-US/docs/Web/CSS/user-select

--- a/core/stylesheets/compass/css3/_user-interface.scss
+++ b/core/stylesheets/compass/css3/_user-interface.scss
@@ -16,16 +16,16 @@ $userselect-support-threshold: $graceful-usage-threshold !default;
 @mixin user-select($select) {
   $select: unquote($select);
 
-  // Controls behavior of the callout and highlight color on iOS and Android devices.
-  @if $select == none {
-    -webkit-tap-highlight-color: rgba(0,0,0,0);
-    -webkit-touch-callout: none;
-  }
-
   @include with-each-prefix(user-select-none, $userselect-support-threshold) {
     // old Firefox used a proprietary `-moz-none` value, starting with Firefox 21 `none` behaves like `-moz-none`
     // @link https://developer.mozilla.org/en-US/docs/Web/CSS/user-select
     @include prefix-prop(user-select, if($current-prefix == -moz and $select == 'none', -moz-none, $select));
+    
+    // Controls behavior of the callout and highlight color on iOS and Android devices.
+    @if($current-prefix == -webkit and $select == 'none') {
+      @include prefix-prop(tap-highlight-color, transparent);
+      @include prefix-prop(touch-callout, none);
+    }
   }
 }
 


### PR DESCRIPTION
These related values, **-webkit-touch-callout** and **-webkit-tap-highlight-color**, control related values to user-select that should be part of the expected behavior when using the mixin to disable selection of texts or objects.
