### PR TITLE
Removed deprecated warning: "Webkit only supports pixels for the start and end stops for radial gradients"

### DIFF
--- a/core/lib/compass/core/sass_extensions/functions/gradient_support.rb
+++ b/core/lib/compass/core/sass_extensions/functions/gradient_support.rb
@@ -693,7 +693,6 @@ module Compass::Core::SassExtensions::Functions::GradientSupport
         if stop.numerator_units == ["%"] && color_list.value.last.stop && color_list.value.last.stop.numerator_units == ["px"]
           stop = stop.times(color_list.value.last.stop).div(number(100, "%"))
         end
-        Compass::Logger.new.record(:warning, "Webkit only supports pixels for the start and end stops for radial gradients. Got: #{orig_stop}") if stop.numerator_units != ["px"]
         stop.div(Sass::Script::Value::Number.new(1, stop.numerator_units, stop.denominator_units))
       elsif stop
         stop


### PR DESCRIPTION
See note at:   https://developer.apple.com/library/safari/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html#//apple_ref/doc/uid/TP40008032-CH10-SW15

```
The -webkit-linear-gradient and webkit-radial-gradient properties require iOS 5.0 or later, or Safari 5.1 or later on the desktop. 
If you need to support earlier releases of iOS or Safari, see “Prior Syntax (-webkit-gradient).”
```

It's not really clear why this warning is there in first place, as even the "Prior Syntax" has an example with start/stop using percentage:   

```
-webkit-gradient(radial, 20% 20%, 0px, 20% 20%, 60px, from(white), to(black))
```
