### PR TITLE
Update _images.scss

### DIFF
--- a/core/stylesheets/compass/css3/_images.scss
+++ b/core/stylesheets/compass/css3/_images.scss
@@ -116,7 +116,12 @@ $browsers-supporting-old-webkit-gradients: (android: ("2.1", "3"));
   @include for-legacy-browsers((ie: "8"), $gradient-support-threshold) {
     @include has-layout;
     $gradient-type: if($orientation == vertical, 0, 1);
+    /* ie 6+ */
     filter: progid:DXImageTransform.Microsoft.gradient(gradientType=#{$gradient-type}, startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}');
+    /* ie8 */
+    -ms-filter:progid:DXImageTransform.Microsoft.gradient(gradientType=#{$gradient-type}, startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}');
+    /* ie10 + */
+    background: -ms-linear-gradient($start-color,$end-color);
   }
 }
 


### PR DESCRIPTION
mixin filter-gradient() does not work correctly in different versions of IE.
and need to IE9 filter: none;
