### PR TITLE
Missing indentation

### DIFF
--- a/compass-style.org/content/reference/compass/helpers/sprites.haml
+++ b/compass-style.org/content/reference/compass/helpers/sprites.haml
@@ -92,7 +92,7 @@ documented_functions:
       Passing `true` for `$use-percentages` results in the background position
       being expressed in percentages instead of pixels. Example:
         
-        background: url('/images/icons.png?12345678') 0 25% no-repeat;
+          background: url('/images/icons.png?12345678') 0 25% no-repeat;
 
 #sprite-width.helper
   %h3


### PR DESCRIPTION
A code example was missing 2 spaces on its indentation and Markdown was parsing it as regular text.
