### PR TITLE
Fix nil engine returned by import-once importer

### DIFF
--- a/import-once/lib/compass/import-once/importer.rb
+++ b/import-once/lib/compass/import-once/importer.rb
@@ -8,7 +8,7 @@ module Compass
       end
 
       def find(uri, options, *args)
-        uri, force_import = handle_force_import(uri)
+        uri, force_import = handle_force_import(uri.gsub(/^\(NOT IMPORTED\) /, ''))
         maybe_replace_with_dummy_engine(super(uri, options, *args), options, force_import)
       end
 


### PR DESCRIPTION
Fixes #1868. @chriseppstein not exactly sure the best way to include this in tests, or whether there's a better spot for the substitution.
