### PR TITLE
User select touch callout

### DIFF
--- a/cli/test/fixtures/stylesheets/compass/css/user-interface.css
+++ b/cli/test/fixtures/stylesheets/compass/css/user-interface.css
@@ -2,6 +2,8 @@
   -moz-user-select: -moz-none;
   -ms-user-select: none;
   -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
   user-select: none; }
 
 *:-moz-placeholder {

--- a/core/stylesheets/compass/css3/_user-interface.scss
+++ b/core/stylesheets/compass/css3/_user-interface.scss
@@ -20,6 +20,12 @@ $userselect-support-threshold: $graceful-usage-threshold !default;
     // old Firefox used a proprietary `-moz-none` value, starting with Firefox 21 `none` behaves like `-moz-none`
     // @link https://developer.mozilla.org/en-US/docs/Web/CSS/user-select
     @include prefix-prop(user-select, if($current-prefix == -moz and $select == 'none', -moz-none, $select));
+
+    // Controls behavior of the callout and highlight color on iOS and Android devices.
+    @if($current-prefix == -webkit and $select == 'none') {
+      @include prefix-prop(tap-highlight-color, transparent);
+      @include prefix-prop(touch-callout, none);
+    }
   }
 }
 

--- a/core/test/integrations/projects/compass/css/user-interface.css
+++ b/core/test/integrations/projects/compass/css/user-interface.css
@@ -2,6 +2,8 @@
   -moz-user-select: -moz-none;
   -ms-user-select: none;
   -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
   user-select: none; }
 
 *:-moz-placeholder {


### PR DESCRIPTION
These related values, -webkit-touch-callout and -webkit-tap-highlight-color, control related values to user-select that should be part of the expected behavior when using the mixin to disable selection of texts or objects.
