### PR TITLE
Don't puke if error.sass_filename returns nil.  Fixes #1883

### DIFF
--- a/cli/lib/compass/sass_compiler.rb
+++ b/cli/lib/compass/sass_compiler.rb
@@ -113,10 +113,10 @@ class Compass::SassCompiler
   def when_compilation_error(error, sass_file, css_file, sourcemap_file)
     @error_count += 1
     if error.respond_to?(:sass_filename)
-      if relativize(error.sass_filename) == relativize(sass_file)
+      if !error.sass_filename.nil? && relativize(error.sass_filename) == relativize(sass_file)
         logger.record :error, "#{relativize(error.sass_filename)} (Line #{error.sass_line}: #{error.message})"
       else
-        logger.record :error, "#{relativize(sass_file)} (Line #{error.sass_line} of #{relativize(error.sass_filename)}: #{error.message})"
+        logger.record :error, "#{relativize(sass_file)} (Line #{error.sass_line} of #{relativize(sass_file)}: #{error.message})"
       end
     else
       logger.record :error, "#{relativize(sass_file)} (#{error.backtrace.first}: #{error.message})"


### PR DESCRIPTION
This fixes the issue in #1883 
