### PR TITLE
Add woff2 mime type for inline_font_files

### DIFF
--- a/core/lib/compass/core/sass_extensions/functions/inline_image.rb
+++ b/core/lib/compass/core/sass_extensions/functions/inline_image.rb
@@ -44,6 +44,8 @@ private
       'font/truetype'
     when /\.woff$/i
       'application/font-woff'
+    when /\.woff2$/i
+      'application/font-woff2'
     when /\.off$/i
       'font/openfont'
     when /\.([a-zA-Z]+)$/


### PR DESCRIPTION
This fixes an error message when using inline_font_files with woff2 files: "A mime type could not be determined ... please specify one explicitly."

As far as I can tell, it is not actually possible to explicitly specify a mime type, as inline_font_files only passes the path argument to compute_mime_type. 

This adds woff2 to the list of mime types in compute_mime_type, which should eliminate an error when calling inline_font_files directly with woff2 files.
