### PR TITLE
More explicit method definition : prefixes

### DIFF
--- a/core/lib/compass/core/caniuse.rb
+++ b/core/lib/compass/core/caniuse.rb
@@ -69,7 +69,7 @@ class Compass::Core::CanIUse
   end
 
   # returns the prefixes needed by the list of browsers given
-  def prefixes(browsers = browsers)
+  def prefixes(browsers = self.browsers)
     result = browsers.map{|b| all_prefixes(b) }
     result.flatten!
     result.uniq!


### PR DESCRIPTION
Fixes the "Warning: circular argument reference - browsers" when using ruby 2.2

There's still some stuff to do to fully support ruby 2.2, that's one small step :)
