### PR TITLE
fix failing test with listen 2.7.12

### DIFF
--- a/cli/gemfiles/listen_2.gemfile
+++ b/cli/gemfiles/listen_2.gemfile
@@ -6,6 +6,6 @@ gem 'sass', '~> 3.3.12'
 gem 'compass', :path => "../"
 gem 'compass-core', :path => "../../core"
 gem 'compass-import-once', :path => "../../import-once"
-gem 'listen', '~> 2.7.1'
+gem 'listen', '2.7.11'
 
 gemspec :path=>"../"


### PR DESCRIPTION
`compass watch` dosen't work with listen 2.7.12
bacause `sass --watch` dosen't work.

https://github.com/sass/sass/pull/1527

By the way, sass 3.4 and listen 2.8 already released. (and this problem fixed on sass 3.4.9)
Perhaps there are no reason to specify sass and listen version.
For that matter, `listen_2.gemfile` is unnecessary any more because compass is not dependent on listen. (#1732)
