### PR TITLE
Let the sprite engine decide file extension

### DIFF
--- a/cli/lib/compass/sass_extensions/functions/sprites.rb
+++ b/cli/lib/compass/sass_extensions/functions/sprites.rb
@@ -175,7 +175,7 @@ module Compass::SassExtensions::Functions::Sprites
   def sprite_url(map)
     verify_map(map, "sprite-url")
     map.generate
-    generated_image_url(identifier("#{map.path}-s#{map.uniqueness_hash}.png"))
+    generated_image_url(identifier("#{map.path}-s#{map.uniqueness_hash}.#{map.file_extension}"))
   end
   declare :sprite_url, [:map]
 

--- a/cli/lib/compass/sass_extensions/sprites/engines.rb
+++ b/cli/lib/compass/sass_extensions/sprites/engines.rb
@@ -11,7 +11,11 @@ module Compass
         def construct_sprite
           raise ::Compass::Error, "You must implement construct_sprite"
         end
-        
+
+        def file_extension
+          'png'
+        end
+
         def save(filename)
           raise ::Compass::Error, "You must implement save(filename)"
         end

--- a/cli/lib/compass/sass_extensions/sprites/sprite_methods.rb
+++ b/cli/lib/compass/sass_extensions/sprites/sprite_methods.rb
@@ -36,7 +36,7 @@ module Compass
         end
 
         def name_and_hash
-          "#{path}-s#{uniqueness_hash}.png"
+          "#{path}-s#{uniqueness_hash}.#{file_extension}"
         end
 
         # The on-the-disk filename of the sprite
@@ -63,7 +63,7 @@ module Compass
         end
         
         def cleanup_old_sprites
-          Sass::Util.glob(File.join(Compass.configuration.generated_images_path, "#{path}-s*.png")).each do |file|
+          Sass::Util.glob(File.join(Compass.configuration.generated_images_path, "#{path}-s*.#{file_extension}")).each do |file|
             log :remove, file
             FileUtils.rm file
             Compass.configuration.run_sprite_removed(file)
@@ -90,6 +90,12 @@ module Compass
             sum.hexdigest[0...10]
           end
           @uniqueness_hash
+        end
+
+        # Returns the file extension for this sprite object as decided by the
+        # sprite engine.
+        def file_extension
+          engine.file_extension
         end
 
         # Saves the sprite engine


### PR DESCRIPTION
Since the sprite engine decides which format to emit, it makes sense
to also let it choose which file extension to use so that web servers
can serve the file with correct mime type.
