### PR TITLE
Fix SASS deprecation warning (fixes #1924)

### DIFF
--- a/core/stylesheets/compass/css3/_box-sizing.scss
+++ b/core/stylesheets/compass/css3/_box-sizing.scss
@@ -16,6 +16,8 @@ $default-box-sizing: border-box !default;
 //
 //     $box-model: [ content-box | border-box | padding-box ]
 @mixin box-sizing($box-model: $default-box-sizing) {
-  $box-model: unquote($box-model);
+  @if type-of($box-model) == string {
+    $box-model: unquote($box-model);
+  }
   @include prefixed-properties(css3-boxsizing, $box-sizing-support-threshold, (box-sizing: $box-model));
 }


### PR DESCRIPTION
For some time now, SASS throws a deprecation warning:

```
DEPRECATION WARNING: Passing null, a non-string value, to unquote() will be an error in future versions of Sass
```

I found an excellent discussion of the issue over at https://github.com/ericam/susy/issues/425 and there is also #1924. The actual code was provided by @sktzoootech. I just wrapped it in this pull request.
