### PR TITLE
Fix an exception that occurs when compressor style is enabled and color is included as filename

### DIFF
--- a/cli/lib/compass/sass_extensions/functions/sprites.rb
+++ b/cli/lib/compass/sass_extensions/functions/sprites.rb
@@ -247,6 +247,24 @@ module Compass::SassExtensions::Functions::Sprites
   declare :sprite_position, [:map, :sprite, :offset_x, :offset_y]
   declare :sprite_position, [:map, :sprite, :offset_x, :offset_y, :use_percentages]
 
+  def convert_sprite_name(sprite)
+    case sprite
+      when Sass::Script::Value::Color
+        rgb = if reversed_color_names.keys.first.size == 3
+                sprite.rgb
+              else
+                # Sass 3.3 includes the alpha channel
+                sprite.rgba
+              end
+        identifier(reversed_color_names[rgb])
+      when Sass::Script::Value::Bool
+        identifier(sprite.to_s)
+      else
+        sprite
+    end
+  end
+  declare :convert_sprite_name, [:sprite]
+
 protected
 
   def get_sprite_file(map, sprite=nil)
@@ -262,23 +280,6 @@ protected
       Sass::Script::Value::Color::HTML4_COLORS_REVERSE
     else
       Sass::Script::Value::Color::COLOR_NAMES_REVERSE
-    end
-  end
-
-  def convert_sprite_name(sprite)
-    case sprite
-      when Sass::Script::Value::Color
-        rgb = if reversed_color_names.keys.first.size == 3
-                sprite.rgb
-              else
-                # Sass 3.3 includes the alpha channel
-                sprite.rgba
-              end
-        identifier(reversed_color_names[rgb])
-      when Sass::Script::Value::Bool
-        identifier(sprite.to_s)
-      else
-        sprite
     end
   end
 

--- a/cli/test/integrations/sprites_test.rb
+++ b/cli/test/integrations/sprites_test.rb
@@ -51,14 +51,14 @@ class SpritesTest < Test::Unit::TestCase
     md5.hexdigest
   end
 
-  def render(scss)
+  def render(scss, opts = {})
     options = Compass.sass_engine_options
     options[:line_comments] = false
     options[:style] = :expanded
     options[:syntax] = :scss
     options[:compass] ||= {}
     options[:compass][:logger] ||= Compass::NullLogger.new
-    css = Sass::Engine.new(scss, options).render
+    css = Sass::Engine.new(scss, options.merge(opts)).render
     # reformat to fit result of heredoc:
     "      #{css.gsub('@charset "UTF-8";', '').gsub(/\n/, "\n      ").strip}\n"
   end
@@ -1002,6 +1002,28 @@ class SpritesTest < Test::Unit::TestCase
     CSS
     assert_correct clean(other_css), clean(css)
    end
+
+  it "should be able to compress the sprite stylesheet correctly" do
+    css = render <<-SCSS, :style => :compressed
+     @import "colors/*.png";
+     @include all-colors-sprites;
+    SCSS
+    other_css = <<-CSS
+     .colors-sprite, .colors-blue, .colors-yellow {
+       background-image: url('/images-tmp/colors-s58671cb5bb.png');
+       background-repeat: no-repeat
+     }
+
+     .colors-blue {
+       background-position: 0 0
+     }
+
+     .colors-yellow {
+       background-position: 0 -10px
+     }
+    CSS
+    assert_correct clean(other_css), clean(css)
+  end
 
   it "should have a sprite_name function that returns the names of the sprites in a sass list" do
     css = render <<-SCSS

--- a/core/stylesheets/compass/utilities/sprites/_base.scss
+++ b/core/stylesheets/compass/utilities/sprites/_base.scss
@@ -78,6 +78,7 @@ $default-sprite-separator: "-" !default;
                $use-percentages: false,
                $separator: $default-sprite-separator) {
   @each $sprite-name in $sprite-names {
+    $sprite-name: convert_sprite_name($sprite-name);
     @if sprite_does_not_have_parent($map, $sprite-name) {
       $full-sprite-name: "#{$prefix}#{$separator}#{$sprite-name}";
       @if sprite_has_valid_selector($full-sprite-name) {


### PR DESCRIPTION
My project has been including color name(e.g. black.png white.png) as sprite targets, but an error occurs because the color name is converted to color code(e.g. `#000`, `#fff`).
This PR should fix the problem.

Also, the error can be reproduced in the test added by this PR.
