### PR TITLE
Removing the equal and putting in a colon

### DIFF
--- a/compass-style.org/content/help/tutorials/configurable-variables.haml
+++ b/compass-style.org/content/help/tutorials/configurable-variables.haml
@@ -23,7 +23,7 @@ classnames:
   In order for these configurable variables to work correctly, you must set the variables
   *before* you import the module. For example:
 
-      $blueprint-grid-columns = 12
+      $blueprint-grid-columns : 12
       @import "blueprint/grid"
 
   Because of this, it is common to have one or more partials


### PR DESCRIPTION
From what I know of Sass, you cannot use `=` for setting variables.
