### PR TITLE
FIXES Broken "Source on Github" links in Code Reference

### DIFF
--- a/compass-style.org/layouts/reference.haml
+++ b/compass-style.org/layouts/reference.haml
@@ -1,5 +1,6 @@
-- gh_url = "http://github.com/chriseppstein/compass/blob/stable/frameworks/"
-- gh_url << "#{item[:framework]}/stylesheets/#{item[:stylesheet]}"
+- gh_url = "http://github.com/chriseppstein/compass/blob/stable/"
+- gh_url << (item[:framework] == 'compass' ? 'core/' : "frameworks/#{item[:framework]}/")
+- gh_url << "stylesheets/#{item[:stylesheet]}"
 %a{:href => gh_url, :rel=>"github-source", :title=>"view source for this module on github"} Source on Github
 
 %h1= item[:title]


### PR DESCRIPTION
This fixes one big part of the problem, but whoever did that massive folder re-org should also make sure all the other repo docs reflect that change.
