### PR TITLE
add MIME type for .woff2 extension

### DIFF
--- a/core/lib/compass/core/sass_extensions/functions/inline_image.rb
+++ b/core/lib/compass/core/sass_extensions/functions/inline_image.rb
@@ -43,7 +43,9 @@ private
     when /\.ttf$/i
       'font/truetype'
     when /\.woff$/i
-      'application/font-woff'
+      'font/woff'
+    when /\.woff2$/i
+      'font/woff2'
     when /\.off$/i
       'font/openfont'
     when /\.([a-zA-Z]+)$/


### PR DESCRIPTION
Add the MIME type for .woff2 files so that `inline_font_files` can also handle the newer WOFF2 font format.
Also changed the MIME type off .woff files from `application/font-woff` to the more concise `font/woff` 
(see https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a )
