### PR TITLE
Normalize paths to forward slashes before comparing

### DIFF
--- a/cli/lib/compass/sass_compiler.rb
+++ b/cli/lib/compass/sass_compiler.rb
@@ -133,7 +133,7 @@ class Compass::SassCompiler
   end
 
   def stylesheet_name(sass_file)
-    if sass_file.index(config.sass_path) == 0
+    if sass_file.gsub('\\', '/').index(config.sass_path.gsub('\\', '/')) == 0
       sass_file[(config.sass_path.length + 1)..-6].sub(/\.css$/,'')
     else
       raise Compass::Error, "Individual stylesheets must be in the sass directory."


### PR DESCRIPTION
I experienced the issue at #1769 and this resolved it for me, basically removes the inconsistencies across paths, when config paths have forward slashes you tend to end up with mixed paths on windows like say `c:/Foo\Bar/Baz`. This is entirely equivalent to `c:/Foo/Bar/Baz` or `c:\Foo\Bar\Baz` to the filesystem, but not to an index check obviously since the strings are different.

Note that I don't really know ruby much so in case there is a cleaner way to normalize the paths please feel free to point me in the right direction, but I can confirm that it worked for me.
