### PR TITLE
% sign missing

### DIFF
--- a/core/stylesheets/compass/_support.scss
+++ b/core/stylesheets/compass/_support.scss
@@ -228,7 +228,7 @@ $css-sel2-support-threshold: $critical-usage-threshold !default;
         }
       }
     } @else if $debug-browser-support {
-      /* Capability #{$capability} is not prefixed with #{$prefix} because #{prefix-usage($prefix, $capability, $capability-options)}% of users are affected which is less than the threshold of #{$threshold}. */
+      /* Capability #{$capability} is not prefixed with #{$prefix} because #{prefix-usage($prefix, $capability, $capability-options)}% of users are affected which is less than the threshold of #{$threshold}%. */
     }
   }
   @include with-prefix(null) {


### PR DESCRIPTION
Now generates, which is not consistent:

```
  /* Capability border-radius is not prefixed with -ms because 0% of users are affected which is less than the threshold of 0.1. */
  /* Capability border-radius is not prefixed with -o because 0% of users are affected which is less than the threshold of 0.1. */
  /* Capability border-radius is prefixed with -webkit because 0.1583% of users need it which is more than the threshold of 0.1%. */
```
