### PR TITLE
Set stretch mixin to not set unspecified values. Closes #2002

### DIFF
--- a/core/stylesheets/compass/layout/_stretching.scss
+++ b/core/stylesheets/compass/layout/_stretching.scss
@@ -15,10 +15,10 @@
 
 // shorthand to stretch element height and width
 
-@mixin stretch($offset-top:0, $offset-right:0, $offset-bottom:0, $offset-left:0) {
+@mixin stretch($offset-top:'', $offset-right:'', $offset-bottom:'', $offset-left:'') {
   position: absolute;
-  @if $offset-top { top: $offset-top; }
-  @if $offset-bottom { bottom: $offset-bottom; }
-  @if $offset-left { left: $offset-left; }
-  @if $offset-right { right: $offset-right; }
+  @if $offset-top { top: #{$offset-top}; }
+  @if $offset-bottom { bottom: #{$offset-bottom}; }
+  @if $offset-left { left: #{$offset-left}; }
+  @if $offset-right { right: #{$offset-right}; }
 }


### PR DESCRIPTION
Stretch mixin should not set 0 values for positions not specified.  If I use stretch and set top, right, left, but don't set bottom.  Mixin sets bottom to 0 whereas my intention was to leave bottom undefined.

Set parameters to be optional rather than assigned default values.

Closes #2002 
