### PR TITLE
fixed instances of 'the the' in comments

### DIFF
--- a/compass-style.org/assets/javascripts/jquery.cookie.js
+++ b/compass-style.org/assets/javascripts/jquery.cookie.js
@@ -27,7 +27,7 @@
  * @option Number|Date expires Either an integer specifying the expiration date from now on in days or a Date object.
  *                             If a negative value is specified (e.g. a date in the past), the cookie will be deleted.
  *                             If set to null or omitted, the cookie will be a session cookie and will not be retained
- *                             when the the browser exits.
+ *                             when the browser exits.
  * @option String path The value of the path atribute of the cookie (default: path of page that created the cookie).
  * @option String domain The value of the domain attribute of the cookie (default: domain of page that created the cookie).
  * @option Boolean secure If true, the secure attribute of the cookie will be set and the cookie transmission will

--- a/core/stylesheets/compass/css3/_background-clip.scss
+++ b/core/stylesheets/compass/css3/_background-clip.scss
@@ -1,7 +1,7 @@
 // Background Clip
 @import "compass/support";
 
-// The the user threshold for background-clip support. Defaults to `$critical-usage-threshold`
+// The user threshold for background-clip support. Defaults to `$critical-usage-threshold`
 $background-clip-support-threshold: $critical-usage-threshold !default;
 
 // The default border-box model: [border-box | padding-box | content-box]

--- a/core/stylesheets/compass/css3/_background-origin.scss
+++ b/core/stylesheets/compass/css3/_background-origin.scss
@@ -1,7 +1,7 @@
 // Background Origin
 @import "compass/support";
 
-// The the user threshold for background-origin support. Defaults to `$critical-usage-threshold`
+// The user threshold for background-origin support. Defaults to `$critical-usage-threshold`
 $background-origin-threshold: $critical-usage-threshold !default;
 
 

--- a/core/stylesheets/compass/css3/_background-size.scss
+++ b/core/stylesheets/compass/css3/_background-size.scss
@@ -1,7 +1,7 @@
 // Background Size
 @import "compass/support";
 
-// The the user threshold for background-clip support. Defaults to `$critical-usage-threshold`
+// The user threshold for background-clip support. Defaults to `$critical-usage-threshold`
 $background-size-threshold: $critical-usage-threshold !default;
 
 //  override to change the default

--- a/core/stylesheets/compass/css3/_border-radius.scss
+++ b/core/stylesheets/compass/css3/_border-radius.scss
@@ -3,7 +3,7 @@
 @import "compass/support";
 
 
-// The the user threshold for border-radius support. Defaults to `$graceful-usage-threshold`
+// The user threshold for border-radius support. Defaults to `$graceful-usage-threshold`
 $border-radius-threshold: $graceful-usage-threshold !default;
 
 // The length of a border-radius to be used by default.

--- a/core/stylesheets/compass/css3/_hyphenation.scss
+++ b/core/stylesheets/compass/css3/_hyphenation.scss
@@ -2,7 +2,7 @@
 
 @import "compass/support";
 
-// The the user threshold for hyphens support.
+// The user threshold for hyphens support.
 // Defaults to `$graceful-usage-threshold`.
 $hyphens-support-threshold: $graceful-usage-threshold !default;
 

--- a/core/stylesheets/compass/css3/_transform.scss
+++ b/core/stylesheets/compass/css3/_transform.scss
@@ -1,6 +1,6 @@
 @import "compass/support";
 
-// The the user threshold for transform support. Defaults to `$graceful-usage-threshold`
+// The user threshold for transform support. Defaults to `$graceful-usage-threshold`
 $transform-support-threshold: $graceful-usage-threshold !default;
 
 // @doc off

--- a/core/stylesheets/compass/css3/_transition.scss
+++ b/core/stylesheets/compass/css3/_transition.scss
@@ -1,6 +1,6 @@
 @import "compass/support";
 
-// The the user threshold for transition support. Defaults to `$graceful-usage-threshold`
+// The user threshold for transition support. Defaults to `$graceful-usage-threshold`
 $transition-support-threshold: $graceful-usage-threshold !default;
 
 


### PR DESCRIPTION
I noticed that there were 8 instances of "The the" throughout the documentation. I fixed them in the comments that the documentation is built from.
