### PR TITLE
cli code refactoring line and space

### DIFF
--- a/cli/lib/compass/commands/default.rb
+++ b/cli/lib/compass/commands/default.rb
@@ -22,7 +22,6 @@ module Compass
       end
     end
     class Default < Base
-      
       class << self
         def option_parser(arguments)
           parser = Compass::Exec::CommandOptionParser.new(arguments)

--- a/cli/lib/compass/commands/extension_command.rb
+++ b/cli/lib/compass/commands/extension_command.rb
@@ -32,12 +32,15 @@ Example:
           parser = Compass::Exec::CommandOptionParser.new(arguments)
           parser.extend(ExtensionsOptionParser)
         end
+
         def usage
           option_parser([]).to_s
         end
+
         def description(command)
           "Manage the list of compass extensions on your system"
         end
+
         def parse!(arguments)
           {:arguments => arguments}
         end
@@ -53,7 +56,6 @@ Example:
         require 'rubygems/gem_runner'
         Gem::GemRunner.new.run(options[:arguments])
       end
-
     end
   end
 end

--- a/cli/lib/compass/commands/help.rb
+++ b/cli/lib/compass/commands/help.rb
@@ -16,7 +16,7 @@ Donating:
 To get help on a particular command please specify the command.
 
 }
-        
+
         primary_commands = Compass::Commands.all.select do |c|
           cmd = Compass::Commands[c]
           cmd.respond_to?(:primary) && cmd.primary
@@ -25,7 +25,7 @@ To get help on a particular command please specify the command.
 
         banner << command_list("Primary Commands:", primary_commands)
         banner << command_list("Other Commands:", other_commands)
- 
+
         banner << "\nAvailable Frameworks & Patterns:\n\n"
         banner << Compass::Frameworks.pretty_print
         banner << "\nGlobal Options:\n"
@@ -55,12 +55,15 @@ To get help on a particular command please specify the command.
           parser.extend(Compass::Exec::GlobalOptionsParser)
           parser.extend(HelpOptionsParser)
         end
+
         def usage
           option_parser([]).to_s
         end
+
         def description(command)
           "Get help on a compass command or extension"
         end
+
         def parse!(arguments)
           parser = option_parser(arguments)
           parser.parse!

--- a/cli/lib/compass/commands/imports.rb
+++ b/cli/lib/compass/commands/imports.rb
@@ -6,7 +6,7 @@ module Compass
       def initialize(working_path, options)
         super
       end
-  
+
       def execute
         print ::Compass::Frameworks::ALL.map{|f|
                   "-I #{f.stylesheets_directory}"
@@ -16,12 +16,14 @@ module Compass
         def description(command)
           "Emit an imports suitable for passing to the sass command-line."
         end
+
         def usage
           "Usage: compass imports\n\n" +
           "Prints out the imports known to compass.\n"+
           "Useful for passing imports to the sass command line:\n" +
           "  sass -r compass `compass imports` a_file_using_compass.sass"
         end
+
         def parse!(arguments)
           if arguments.join("").strip.size > 0
             raise OptionParser::ParseError, "This command takes no options or arguments."

--- a/cli/lib/compass/commands/list_frameworks.rb
+++ b/cli/lib/compass/commands/list_frameworks.rb
@@ -6,7 +6,7 @@ module Compass
       def initialize(working_path, options)
         super
       end
-  
+
       def execute
         if options[:quiet]
           Compass::Frameworks::ALL.each do |framework|
@@ -22,12 +22,15 @@ module Compass
           parser = Compass::Exec::CommandOptionParser.new(arguments)
           parser.extend(Compass::Exec::GlobalOptionsParser)
         end
+
         def usage
           option_parser([]).to_s
         end
+
         def description(command)
           "List the available frameworks"
         end
+
         def parse!(arguments)
           parser = option_parser(arguments)
           parser.parse!

--- a/cli/lib/compass/commands/print_version.rb
+++ b/cli/lib/compass/commands/print_version.rb
@@ -39,17 +39,21 @@ Options:
           parser = Compass::Exec::CommandOptionParser.new(arguments)
           parser.extend(VersionOptionsParser)
         end
+
         def usage
           option_parser([]).to_s
         end
+
         def description(command)
           "Print out version information"
         end
+
         def parse!(arguments)
           parser = option_parser(arguments)
           parser.parse!
           parser.options
         end
+
         def long_output_string
           lines = []
           lines << "Compass #{::Compass.version[:string]}"
@@ -69,7 +73,7 @@ Options:
       def initialize(working_path, options)
         self.options = options
       end
-  
+
       def execute
         if options[:custom]
           version = ""

--- a/cli/lib/compass/commands/registry.rb
+++ b/cli/lib/compass/commands/registry.rb
@@ -4,11 +4,13 @@ module Compass::Commands
       @commands ||= Hash.new
       @commands[name.to_sym] = command_class
     end
+
     def get(name)
       return unless name
       @commands ||= Hash.new
       @commands[name.to_sym] || @commands[abbreviation_of(name)]
     end
+
     def abbreviation_of(name)
       re = /^#{Regexp.escape(name)}/
       matching = @commands.keys.select{|k| k.to_s =~ re}
@@ -22,14 +24,17 @@ module Compass::Commands
         raise Compass::Error, "Command not found: #{name}"
       end
     end
+
     def abbreviation?(name)
       re = /^#{Regexp.escape(name)}/
       @commands.keys.detect{|k| k.to_s =~ re}
     end
+
     def command_exists?(name)
       @commands ||= Hash.new
       name && (@commands.has_key?(name.to_sym) || abbreviation?(name))
     end
+
     def all
       @commands.keys
     end

--- a/cli/lib/compass/commands/stamp_pattern.rb
+++ b/cli/lib/compass/commands/stamp_pattern.rb
@@ -35,18 +35,22 @@ Options:
           parser.extend(Compass::Exec::ProjectOptionsParser)
           parser.extend(StampPatternOptionsParser)
         end
+
         def usage
           option_parser([]).to_s
         end
+
         def description(command)
           "Install an extension's pattern into your compass project"
         end
+
         def parse!(arguments)
           parser = option_parser(arguments)
           parser.parse!
           parse_arguments!(parser, arguments)
           parser.options
         end
+
         def parse_arguments!(parser, arguments)
           if arguments.size == 0
             raise OptionParser::ParseError, "Please specify a pattern."
@@ -61,7 +65,6 @@ Options:
             raise OptionParser::ParseError, "Unexpected trailing arguments: #{arguments.join(" ")}"
           end
         end
-
       end
       include InstallerCommand
 
@@ -84,7 +87,6 @@ Options:
       def template_directory(pattern)
         File.join(framework.templates_directory, pattern)
       end
-
     end
   end
 end

--- a/cli/lib/compass/exec/command_option_parser.rb
+++ b/cli/lib/compass/exec/command_option_parser.rb
@@ -1,21 +1,25 @@
 module Compass::Exec
   class CommandOptionParser
     attr_accessor :options, :arguments, :opts
+
     def initialize(arguments)
       self.arguments = arguments
       self.options = {}
     end
+
     def parse!
       opts.parse!(arguments)
     end
+
     def opts
       OptionParser.new do |opts|
         self.set_options(opts)
       end
     end
-    def set_options(opts)
 
+    def set_options(opts)
     end
+
     def to_s
       opts.to_s
     end

--- a/cli/lib/compass/installers/manifest.rb
+++ b/cli/lib/compass/installers/manifest.rb
@@ -12,6 +12,7 @@ module Compass
       end
 
       attr_reader :options
+
       def initialize(manifest_file = nil, options = {})
         @entries = []
         @options = options
@@ -142,20 +143,18 @@ module Compass
       def parse(manifest_file)
         with_manifest(manifest_file) do
           if File.exists?(manifest_file)
-            open(manifest_file) do |f| 
+            open(manifest_file) do |f|
               eval(f.read, instance_binding, manifest_file)
-            end 
+            end
           else
               eval("discover :all", instance_binding, manifest_file)
-          end 
-        end 
-      end 
-
+          end
+        end
+      end
 
       def instance_binding
         binding
       end
     end
-
   end
 end

--- a/cli/lib/compass/stats.rb
+++ b/cli/lib/compass/stats.rb
@@ -2,12 +2,14 @@ module Compass
   module Stats
     class StatsVisitor
       attr_accessor :rule_count, :prop_count, :mixin_def_count, :mixin_count
+
       def initialize
         self.rule_count = 0
         self.prop_count = 0
         self.mixin_def_count = 0
         self.mixin_count = 0
       end
+
       def visit(node)
         self.prop_count += 1 if node.is_a?(Sass::Tree::PropNode) && !node.children.any?
         if node.is_a?(Sass::Tree::RuleNode)
@@ -16,20 +18,25 @@ module Compass
         self.mixin_def_count += 1 if node.is_a?(Sass::Tree::MixinDefNode)
         self.mixin_count += 1 if node.is_a?(Sass::Tree::MixinNode)
       end
+
       def up(node)
       end
+
       def down(node)
       end
+
       def import?(node)
         return false
         full_filename = node.send(:import)
         full_filename != Compass.deprojectize(full_filename)
       end
     end
+
     class CssFile
       attr_accessor :path, :css
       attr_accessor :selector_count, :prop_count
       attr_accessor :file_size
+
       def initialize(path)
         require 'css_parser'
         self.path = path
@@ -38,12 +45,15 @@ module Compass
         self.selector_count = 0
         self.prop_count = 0
       end
+
       def contents
         @contents ||= File.read(path)
       end
+
       def lines
         contents.inject(0){|m,c| m + 1 }
       end
+
       def analyze!
         self.file_size = File.size(path)
         css.each_selector do |selector, declarations, specificity|
@@ -54,6 +64,7 @@ module Compass
         end
       end
     end
+
     class SassFile
       attr_accessor :path
       attr_reader :visitor
@@ -62,35 +73,44 @@ module Compass
       def initialize(path)
         self.path = path
       end
+
       def contents
         @contents ||= File.read(path)
       end
+
       def tree
         opts = Compass.configuration.to_sass_engine_options
         opts[:syntax] = path[-4..-1].to_sym
         @tree = Sass::Engine.new(contents, opts).to_tree
       end
+
       def visit_tree!
         @visitor = StatsVisitor.new
         tree.visit_depth_first(@visitor)
         @visitor
       end
+
       def analyze!
         self.file_size = File.size(path)
         visit_tree!
       end
+
       def lines
         contents.inject(0){|m,c| m + 1 }
       end
+
       def rule_count
         visitor.rule_count
       end
+
       def prop_count
         visitor.prop_count
       end
+
       def mixin_def_count
         visitor.mixin_def_count
       end
+
       def mixin_count
         visitor.mixin_count
       end


### PR DESCRIPTION
add new line and delete space, because Code is difficult to read.

```
def foo
end
def bar
end
```

to

```
def foo
end

def bar
end
```
