### PR TITLE
Modified default value of http_generated_images_dir to fall back to generated_images_dir instead of http_images_dir.

### DIFF
--- a/core/lib/compass/configuration/defaults.rb
+++ b/core/lib/compass/configuration/defaults.rb
@@ -118,7 +118,7 @@ module Compass
       end
 
       def default_http_generated_images_dir
-        top_level.http_images_dir
+        top_level.generated_images_dir
       end
 
       def default_http_images_dir


### PR DESCRIPTION
The documentation indicates that http_generated_images_path if unset should default to http_path + generated_images_dir.  The current behavior, however, is for http_generated_images_path to default to http_images_path.  If generated_images_dir is changed, http_generated_images_path does not change.  This patch changes the default value of http_generated_images_dir to correspond with the documentation.  

Existing configurations that rely on changes to http_images_path to affect the default value of http_generated_images_path are incompatible with this change, however, it is more useful to maintain the logical correspondence between http_generated_images_path and generated_images_dir, which is specified by the current documentation.
