### PR TITLE
Fix no implicit conversion of Sprockets::Asset into String #2042

### DIFF
--- a/core/lib/compass/core/sass_extensions/functions/image_size.rb
+++ b/core/lib/compass/core/sass_extensions/functions/image_size.rb
@@ -15,7 +15,7 @@ module Compass::Core::SassExtensions::Functions::ImageSize
 
   class ImageProperties
     def initialize(file)
-      @file = (file.respond_to?(:to_path) ? file.to_path : file)
+      @file = (file.respond_to?(:filename) ? file.filename : file)
       @file_type = File.extname(@file)[1..-1].downcase
       unless KNOWN_TYPES.include?(@file_type)
         raise Sass::SyntaxError, "Unrecognized file type: #{@file_type}"


### PR DESCRIPTION
Fix #2042
Fix https://github.com/Compass/compass-rails/issues/256/

I am by no means familiar with the code.
I guess assume the issue has to do with Sprockets 3 support...
