### PR TITLE
Fix links to source code on compass-style.org

### DIFF
--- a/compass-style.org/layouts/reference.haml
+++ b/compass-style.org/layouts/reference.haml
@@ -1,5 +1,4 @@
-- gh_url = "http://github.com/chriseppstein/compass/blob/stable/frameworks/"
-- gh_url << "#{item[:framework]}/stylesheets/#{item[:stylesheet]}"
+- gh_url = "https://github.com/Compass/compass/blob/stable/core/stylesheets/#{item[:stylesheet]}"
 %a{:href => gh_url, :rel=>"github-source", :title=>"view source for this module on github"} Source on Github
 
 %h1= item[:title]


### PR DESCRIPTION
The "Source on Github" links, like the one [here](http://compass-style.org/reference/compass/css3/) points to URLs that are no longer correct. 
