### PR TITLE
Feature/fix broken links

### DIFF
--- a/compass-style.org/README.markdown
+++ b/compass-style.org/README.markdown
@@ -291,7 +291,7 @@ All of these are optional and have reasonable defaults, you can use them when un
 **Note**: When generating examples or references, Thor is searching for the appropriate
 module stylesheet. If it doesn't find one, it raises an error and doesn't
 generate anything. So before generating anything make sure the stylesheet exists and is
-under `../frameworks/compass/stylesheets/compass/path/to/module` (relative to the `compass-style.org` directory). If the path confuses you, just take a few minutes to study how other modules are organized and you'll quickly get the hang of it.
+under `../core/stylesheets/compass/path/to/module` (relative to the `compass-style.org` directory). If the path confuses you, just take a few minutes to study how other modules are organized and you'll quickly get the hang of it.
 
 Let's do an example:
 
@@ -345,7 +345,7 @@ After adding the example and adjusting the metadata, go to the reference page in
 Existing modules already have reference files, so you'll most likely be adding
 reference files to new modules.
 
-So we got a great idea for an awesome module, and after a lot of thinking we decided to name it `super-awesome-module`. The first step to adding a new module is creating the stylesheet. Let's say this will be a Compass CSS3 module, so we'll create a new file as `../frameworks/compass/stylesheets/compass/css3/_super-awesome-module.scss` (relative to the `compass-style.org` directory). Keep in mind that the comments inside those stylesheets are parsed with Markdown and output into the reference.
+So we got a great idea for an awesome module, and after a lot of thinking we decided to name it `super-awesome-module`. The first step to adding a new module is creating the stylesheet. Let's say this will be a Compass CSS3 module, so we'll create a new file as `../core/stylesheets/compass/css3/_super-awesome-module.scss` (relative to the `compass-style.org` directory). Keep in mind that the comments inside those stylesheets are parsed with Markdown and output into the reference.
 
 The easiest way to find out how you should write your stylesheet is to take a look at some existing modules. This module won't be very useful, but you'll get the point:
 

--- a/compass-style.org/content/reference/compass/helpers/cross-browser.haml
+++ b/compass-style.org/content/reference/compass/helpers/cross-browser.haml
@@ -1,4 +1,4 @@
---- 
+---
 title: Compass Cross Browser Helpers
 crumb: Cross Browser
 framework: compass
@@ -24,15 +24,15 @@ documented_functions:
 :markdown
   These helpers are used by compass to create mixins that can insulate
   the user from cross browser syntax and vendor prefix complexities.
-  
+
   If you need to support a new experimental (prefixed) function in your
   project using these helpers, you can add support for it adding the following
   to your compass configuration file:
-  
+
       Compass::BrowserSupport.add_support("function-name", "webkit", "moz")
 
   For an example of how to use these functions see the
-  [compass images module](https://github.com/chriseppstein/compass/blob/master/frameworks/compass/stylesheets/compass/css3/_images.scss).
+  [compass images module](https://github.com/chriseppstein/compass/blob/master/core/stylesheets/compass/css3/_images.scss).
 
 #prefixed.helper
   %h3

--- a/compass-style.org/layouts/reference.haml
+++ b/compass-style.org/layouts/reference.haml
@@ -1,5 +1,5 @@
-- gh_url = "http://github.com/chriseppstein/compass/blob/stable/frameworks/"
-- gh_url << "#{item[:framework]}/stylesheets/#{item[:stylesheet]}"
+- gh_url = "http://github.com/chriseppstein/compass/blob/stable/core/"
+- gh_url << "stylesheets/#{item[:stylesheet]}"
 %a{:href => gh_url, :rel=>"github-source", :title=>"view source for this module on github"} Source on Github
 
 %h1= item[:title]

--- a/compass-style.org/tasks/generators.thor
+++ b/compass-style.org/tasks/generators.thor
@@ -61,10 +61,10 @@ class Generate < Thor
     open(file_name, "w") do |example_file|
       example_contents = <<-EXAMPLE
         | @import "#{module_path}";
-        | 
+        |
         | // This file is used to style the example markup.
         | // And the source is shown to the user as SCSS, Sass and as CSS.
-        | 
+        |
         | .example {
         |   .title {
         |     font-size: 36px;
@@ -72,7 +72,7 @@ class Generate < Thor
         |     color: #333;
         |     border: none;
         |   }
-        | 
+        |
         |   p { color: #666; }
         | }
       EXAMPLE
@@ -128,7 +128,7 @@ class Generate < Thor
     stylesheet_name = array.pop
     prefix = array.join("/")
 
-    stylesheet = Dir["../frameworks/compass/stylesheets/#{prefix}/_#{stylesheet_name}.{scss,sass}"].first
+    stylesheet = Dir["../core/stylesheets/#{prefix}/_#{stylesheet_name}.{scss,sass}"].first
     raise "no stylesheet found for module #{module_path}" if stylesheet.nil?
     stylesheet = File.expand_path(stylesheet)
 


### PR DESCRIPTION
Fixes #2051, #2055, #2009, #1949, #1905, and it seems a bunch of others.

Should I also remove the `framework:` key? example: https://github.com/Compass/compass/blob/stable/compass-style.org/content/reference/compass/css3/background_origin.haml#L4
