### PR TITLE
fix UMDF donation url

### DIFF
--- a/cli/compass.gemspec
+++ b/cli/compass.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gemspec|
   gemspec.add_dependency 'rb-inotify', '>= 0.9'
 
   gemspec.post_install_message = <<-MESSAGE
-    Compass is charityware. If you love it, please donate on our behalf at http://umdf.org/compass Thanks!
+    Compass is charityware. If you love it, please donate on our behalf at http://umdf.org/ Thanks!
   MESSAGE
 
   gemspec.files = %w(LICENSE.markdown VERSION VERSION_NAME Rakefile)
@@ -36,4 +36,3 @@ Gem::Specification.new do |gemspec|
   gemspec.test_files -= Dir.glob("test/fixtures/stylesheets/*/saved/**/*.*")
   gemspec.test_files += Dir.glob("features/**/*.*")
 end
-

--- a/cli/lib/compass/commands/help.rb
+++ b/cli/lib/compass/commands/help.rb
@@ -11,12 +11,12 @@ Description:
 
 Donating:
   Compass is charityware. If you find it useful please make
-  a tax deductable donation: http://umdf.org/compass
+  a tax deductable donation: http://umdf.org/
 
 To get help on a particular command please specify the command.
 
 }
-        
+
         primary_commands = Compass::Commands.all.select do |c|
           cmd = Compass::Commands[c]
           cmd.respond_to?(:primary) && cmd.primary
@@ -25,7 +25,7 @@ To get help on a particular command please specify the command.
 
         banner << command_list("Primary Commands:", primary_commands)
         banner << command_list("Other Commands:", other_commands)
- 
+
         banner << "\nAvailable Frameworks & Patterns:\n\n"
         banner << Compass::Frameworks.pretty_print
         banner << "\nGlobal Options:\n"
@@ -48,7 +48,7 @@ To get help on a particular command please specify the command.
     end
     class Help < Base
       register :help
-      
+
       class << self
         def option_parser(arguments)
           parser = Compass::Exec::CommandOptionParser.new(arguments)

--- a/cli/lib/compass/commands/print_version.rb
+++ b/cli/lib/compass/commands/print_version.rb
@@ -59,7 +59,7 @@ Options:
           lines << "Copyright (c) 2008-#{Time.now.year} Chris Eppstein"
           lines << "Released under the MIT License."
           lines << "Compass is charityware."
-          lines << "Please make a tax deductable donation for a worthy cause: http://umdf.org/compass"
+          lines << "Please make a tax deductable donation for a worthy cause: http://umdf.org/"
           lines.join("\n")
         end
       end
@@ -69,7 +69,7 @@ Options:
       def initialize(working_path, options)
         self.options = options
       end
-  
+
       def execute
         if options[:custom]
           version = ""

--- a/compass-style.org/content/get-involved/index.haml
+++ b/compass-style.org/content/get-involved/index.haml
@@ -30,4 +30,4 @@ layout: default
   ## Give Financially
 
   Compass is charityware. You can use it as much as you like, but we encourage you to make a donation to help the [UMDF](http://umdf.org/)
-  find a cure for mitochondrial disease. If you can, please [donate here](http://umdf.org/compass/). Thanks!
+  find a cure for mitochondrial disease. If you can, please [donate here](http://umdf.org/). Thanks!

--- a/compass-style.org/content/posts/2011-04-24-v011-release.markdown
+++ b/compass-style.org/content/posts/2011-04-24-v011-release.markdown
@@ -8,7 +8,7 @@ The Compass team is proud to announce that v0.11 is released. With this release,
 
 In this post, we summarize the new features. For all the nitty gritty details, see the [CHANGELOG](/CHANGELOG/).
 
-Compass is Charityware. If you love this release, [please donate to the UMDF](http://umdf.org/compass) on our behalf and help find a cure for thousands of children suffering from mitochondrial disease.
+Compass is Charityware. If you love this release, [please donate to the UMDF](http://umdf.org/) on our behalf and help find a cure for thousands of children suffering from mitochondrial disease.
 
 ## Sass 3.1
 

--- a/compass-style.org/layouts/partials/footer.haml
+++ b/compass-style.org/layouts/partials/footer.haml
@@ -7,7 +7,7 @@
       Compass is Charityware -
       <br>
       Help the UMDF:
-      %a(href="http://umdf.org/compass") Donate Now!
+      %a(href="http://umdf.org/") Donate Now!
     %li
       %strong Problem with this page?
       <br>


### PR DESCRIPTION
Currently, the umdf donation url points to http://umdf.org/compass which does not exist anymore.  This pull request changes the url to http://umdf.org/ so would be donors arrive at the home page.