### PR TITLE
Update homepage to show notice about deprecation of compass and suggest other tools

### DIFF
--- a/compass-style.org/content/index.haml
+++ b/compass-style.org/content/index.haml
@@ -7,6 +7,12 @@ layout: homepage
 %h1#logo Compass
 %h2 <strong>Compass</strong> is an open-source <em>CSS Authoring Framework</em>.
 .overview
+  .info-box.error
+    %h4 Compass is deprecated
+    %p
+      Use other tools such as <a href="https://github.com/thoughtbot/bourbon">bourbon</a>, 
+      <a href="https://github.com/sindresorhus/grunt-sass">grunt-sass</a> or
+      <a href="https://github.com/sass/node-sass">node-sass</a> directly.
   .info-box.compass
     %h4 Why designers love Compass.
     %ol


### PR DESCRIPTION
Didn 't have the time to find out how to test whether the website looks OK or whether the notice stands out with this.

I'm relying on other people here to do this who know how to do it.

Just thought it's good not to lead users in the wrong direction with the site.

Big thanks to the contributors of compass for your work on it!