### PR TITLE
Support Sass 3.5

### DIFF
--- a/core/compass-core.gemspec
+++ b/core/compass-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sass", ">= 3.3.0", "< 3.5"
+  spec.add_dependency "sass", ">= 3.3.0"
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I'm not sure why we are stopping using the "latest" version.