### PR TITLE
Update 3 gemspec files to support sass 3.5.

### DIFF
--- a/cli/compass.gemspec
+++ b/cli/compass.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gemspec|
   gemspec.rubygems_version = "1.3.5"
   gemspec.summary = %q{A Real Stylesheet Framework}
 
-  gemspec.add_dependency 'sass', '>= 3.3.13', '< 3.5'
+  gemspec.add_dependency 'sass', '>= 3.3.13', '< 3.6'
   gemspec.add_dependency 'compass-core', "~> #{File.read(File.join(File.dirname(__FILE__),"..","core","VERSION")).strip}"
   gemspec.add_dependency 'compass-import-once', "~> #{File.read(File.join(File.dirname(__FILE__),"..","import-once","VERSION")).strip}"
   gemspec.add_dependency 'chunky_png', '~> 1.2'

--- a/core/compass-core.gemspec
+++ b/core/compass-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sass", ">= 3.3.0", "< 3.5"
+  spec.add_dependency "sass", ">= 3.3.0", "< 3.6"
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/import-once/compass-import-once.gemspec
+++ b/import-once/compass-import-once.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sass", ">= 3.2", "< 3.5"
+  spec.add_dependency "sass", ">= 3.2", "< 3.6"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "diff-lcs"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Relax dependency conditions to use sass 3.5.

Updated `compass`, `compass-core` and `compass-import-once` gemspec files.
This approach to remain `< 3.6` is better than https://github.com/Compass/compass/pull/2138 to suppress the warning when run `gem build compass.gemspec`.

I am sorry that these gems are actively maintained.
