### PR TITLE
Add support for CSS var()

### DIFF
--- a/core/lib/compass/core/sass_extensions/functions/gradient_support.rb
+++ b/core/lib/compass/core/sass_extensions/functions/gradient_support.rb
@@ -162,7 +162,8 @@ module Compass::Core::SassExtensions::Functions::GradientSupport
       unless Sass::Script::Value::Color === color ||
              Sass::Script::Tree::Funcall === color ||
              (Sass::Script::Value::String === color && color.value == "currentColor")||
-             (Sass::Script::Value::String === color && color.value == "transparent")
+             (Sass::Script::Value::String === color && color.value == "transparent") ||
+             (Sass::Script::Value::String === color && color.value.start_with?("var("))
         raise Sass::SyntaxError, "Expected a color. Got: #{color}"
       end
     end


### PR DESCRIPTION
When using older projects using Compass, the CSS var() syntax not supported and an error message may be triggered.
`Expected a color. Got: var(--foo, 'bar')`

This quick fix add support for it while you can quietly prepare to update your build stack to latest versions with a coffee ^^